### PR TITLE
Finish podcast archive links and offline backup tooling

### DIFF
--- a/docs/podcast-transistor-migration.md
+++ b/docs/podcast-transistor-migration.md
@@ -12,7 +12,7 @@ https://swyx.io/rss.xml
 
 ## Shows
 
-| Transistor show        | Published episodes | New canonical feed                                     |
+| Transistor show        | Archived episodes | New canonical feed                                     |
 | ---------------------- | -----------------: | ------------------------------------------------------ |
 | `learn-in-podcast`     |                540 | `https://swyx.io/podcast/learn-in-podcast/rss.xml`     |
 | `the-temporal-podcast` |                 25 | `https://swyx.io/podcast/the-temporal-podcast/rss.xml` |
@@ -24,6 +24,54 @@ The Transistor dashboard also reported 6 draft-filter rows for
 feed, three unpublished MP3s were preserved under unlinked checksum-addressed R2
 paths, one metadata-only draft had no downloadable audio, and one row was
 already present in the migrated archive feed.
+
+The August 25 audit matched all 582 currently published Transistor episode
+titles to the archive. The 583rd archive episode is the Chainsmokers draft
+published directly on swyx.io. Channel website links should point to
+`https://swyx.io/podcasts#<slug>`; RSS self-links and feed redirects continue to
+use `https://swyx.io/podcast/<slug>/rss.xml`.
+
+## Offline backup and legacy website cutover
+
+The original ignored `.podcast-migration` staging directory is not guaranteed to
+survive checkout cleanup. Keep a full offline backup outside the repository.
+Given a **complete** Cloudflare R2 List Objects JSON response, the backup script
+downloads the podcast bucket snapshot without changing remote objects:
+
+```sh
+node scripts/backup-podcast-r2.mjs /path/to/r2-objects.json /path/to/offline-backup
+```
+
+Downloads are streamed with three concurrent requests. Each object is checked
+against its recorded byte length, single-part ETag/MD5 where applicable, and
+the SHA-256 prefix in checksum-addressed filenames. The script records full
+SHA-256s in `manifest.json` and `SHA256SUMS`. Reruns hash and verify completed
+files before skipping them. Ctrl-C stops the process; rerun the same command to
+resume. Keep the directory private because it includes unpublished drafts and
+administrative metadata. This backs up the current R2 inventory, not the
+missing original Transistor staging manifests or analytics exports.
+
+The dedicated `wrangler.podcast-redirects.toml` deploy target restores
+`mixtape.swyx.io` as a Cloudflare Custom Domain and sends all legacy website
+paths to the Mixtape archive. It does not redeploy the main website:
+
+```sh
+npx wrangler deploy --config wrangler.podcast-redirects.toml
+```
+
+Code, deployment, and live DNS/HTTP verification are separate steps. The
+Transistor-owned `temporal.transistor.fm` and `careerchats.transistor.fm`
+hostnames cannot be configured in our Cloudflare zone; their website redirect
+behavior must be configured in Transistor or arranged with Transistor support.
+Do not substitute a JavaScript redirect for a durable provider-level 301 after
+account cancellation. Website redirects are separate from the three existing
+RSS redirects.
+
+Before repairing existing R2 feed objects, snapshot each current XML and ETag.
+Run `ensureCanonicalFeedLinks` and verify every episode item is unchanged; do
+not re-upload a historical replacement feed over newer studio publications.
+Publish with an ETag condition, then read back the canonical RSS URL and verify
+both its website link and unchanged episode/GUID/media inventory.
 
 ## Cloudflare Storage
 

--- a/scripts/backup-podcast-r2.mjs
+++ b/scripts/backup-podcast-r2.mjs
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+import { createHash } from 'node:crypto';
+import { createReadStream, createWriteStream } from 'node:fs';
+import { mkdir, readFile, rename, stat, statfs, writeFile } from 'node:fs/promises';
+import { dirname, resolve, sep } from 'node:path';
+import { Readable, Transform } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+import { pathToFileURL } from 'node:url';
+
+export function backupPath(root, key) {
+	if (!key || key.split('/').some((part) => !part || part === '.' || part === '..')) {
+		throw new Error('Invalid object key');
+	}
+	const path = resolve(root, key);
+	if (!path.startsWith(`${resolve(root)}${sep}`)) throw new Error('Object key escapes backup');
+	return path;
+}
+
+export function verifyObject(object, actual) {
+	if (actual.size !== object.size) throw new Error(`Size mismatch: ${object.key}`);
+	const etag = object.etag.replaceAll('"', '');
+	if (/^[a-f0-9]{32}$/i.test(etag) && actual.md5 !== etag) {
+		throw new Error(`ETag/MD5 mismatch: ${object.key}`);
+	}
+	const prefix = object.key
+		.split('/')
+		.at(-1)
+		.match(/^([a-f0-9]{64}|[a-f0-9]{16})-/)?.[1];
+	if (prefix && !actual.sha256.startsWith(prefix)) {
+		throw new Error(`SHA-256 mismatch: ${object.key}`);
+	}
+}
+
+async function hashFile(path) {
+	const sha = createHash('sha256');
+	const md5 = createHash('md5');
+	let size = 0;
+	for await (const chunk of createReadStream(path)) {
+		size += chunk.length;
+		sha.update(chunk);
+		md5.update(chunk);
+	}
+	return { size, sha256: sha.digest('hex'), md5: md5.digest('hex') };
+}
+
+async function main() {
+	const [inventoryPath, outputPath] = process.argv.slice(2);
+	if (!inventoryPath || !outputPath) {
+		throw new Error('Usage: node scripts/backup-podcast-r2.mjs INVENTORY.json OUTPUT_DIRECTORY');
+	}
+	const inventory = JSON.parse(await readFile(inventoryPath, 'utf8'));
+	if (!inventory.success || !Array.isArray(inventory.result))
+		throw new Error('Invalid R2 inventory');
+	const objects = inventory.result;
+	const root = resolve(outputPath);
+	await mkdir(root, { recursive: true, mode: 0o700 });
+	const disk = await statfs(root);
+	let remainingBytes = 0;
+	for (const object of objects) {
+		const path = backupPath(`${root}/objects`, object.key);
+		const existing = await stat(path).catch(() => null);
+		if (existing?.size !== object.size) remainingBytes += object.size;
+	}
+	if (disk.bavail * disk.bsize < remainingBytes + 2 * 1024 ** 3) {
+		throw new Error(
+			`Insufficient free space for ${remainingBytes} remaining bytes plus 2 GiB reserve`
+		);
+	}
+	await writeFile(`${root}/inventory.json`, JSON.stringify(inventory, null, 2), { mode: 0o600 });
+	const completed = [];
+	let cursor = 0;
+	let bytes = 0;
+	let save = Promise.resolve();
+	const checkpoint = () => {
+		const data = JSON.stringify(
+			{
+				checkedAt: new Date().toISOString(),
+				complete: completed.length === objects.length,
+				objects: [...completed]
+			},
+			null,
+			2
+		);
+		save = save.then(async () => {
+			await writeFile(`${root}/manifest.json.tmp`, data, { mode: 0o600 });
+			await rename(`${root}/manifest.json.tmp`, `${root}/manifest.json`);
+		});
+		return save;
+	};
+	async function worker() {
+		while (cursor < objects.length) {
+			const object = objects[cursor++];
+			const path = backupPath(`${root}/objects`, object.key);
+			let actual;
+			if ((await stat(path).catch(() => null))?.size === object.size) {
+				actual = await hashFile(path);
+				verifyObject(object, actual);
+			} else {
+				await mkdir(dirname(path), { recursive: true, mode: 0o700 });
+				const url = `https://media.swyx.io/${object.key.split('/').map(encodeURIComponent).join('/')}`;
+				let lastError;
+				for (let attempt = 0; attempt < 3; attempt++) {
+					try {
+						const response = await fetch(url, {
+							headers: {
+								'If-Match': `"${object.etag.replaceAll('"', '')}"`,
+								'Accept-Encoding': 'identity'
+							},
+							signal: AbortSignal.timeout(600_000)
+						});
+						if (!response.ok) throw new Error(`HTTP ${response.status}: ${object.key}`);
+						const sha = createHash('sha256');
+						const md5 = createHash('md5');
+						let size = 0;
+						const hashing = new Transform({
+							transform(chunk, _encoding, next) {
+								size += chunk.length;
+								sha.update(chunk);
+								md5.update(chunk);
+								next(null, chunk);
+							}
+						});
+						await pipeline(
+							Readable.fromWeb(response.body),
+							hashing,
+							createWriteStream(`${path}.part`, { mode: 0o600 })
+						);
+						actual = { size, sha256: sha.digest('hex'), md5: md5.digest('hex') };
+						verifyObject(object, actual);
+						await rename(`${path}.part`, path);
+						lastError = null;
+						break;
+					} catch (error) {
+						lastError = error;
+					}
+				}
+				if (lastError) throw lastError;
+			}
+			completed.push({ ...object, ...actual });
+			bytes += actual.size;
+			await checkpoint();
+			if (completed.length % 25 === 0 || completed.length === objects.length) {
+				console.log(
+					`${completed.length}/${objects.length} objects; ${(bytes / 1e9).toFixed(2)} GB verified`
+				);
+			}
+		}
+	}
+	console.log(`Backing up ${objects.length} objects to ${root}; streamed downloads, 3 concurrent`);
+	await Promise.all([worker(), worker(), worker()]);
+	await save;
+	await writeFile(
+		`${root}/SHA256SUMS`,
+		completed
+			.sort((a, b) => a.key.localeCompare(b.key))
+			.map((o) => `${o.sha256}  objects/${o.key}`)
+			.join('\n') + '\n',
+		{ mode: 0o600 }
+	);
+	console.log(`Complete: ${completed.length} objects, ${bytes} bytes; SHA256SUMS written`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+	main().catch((error) => {
+		console.error(error.message);
+		process.exitCode = 1;
+	});
+}

--- a/scripts/lib/podcast-feed.mjs
+++ b/scripts/lib/podcast-feed.mjs
@@ -114,6 +114,10 @@ export function canonicalFeedUrl(slug) {
 	return `https://swyx.io/podcast/${assertSlug(slug)}/rss.xml`;
 }
 
+export function canonicalWebsiteUrl(slug) {
+	return `https://swyx.io/podcasts#${assertSlug(slug)}`;
+}
+
 export function joinUrl(base, key) {
 	return `${base.replace(/\/+$/, '')}/${key.replace(/^\/+/, '')}`;
 }
@@ -335,7 +339,17 @@ export function collectFeed(document, sourceUrl) {
 export function ensureCanonicalFeedLinks(document, slug) {
 	const { rss, channel } = rssAndChannel(document);
 	const feedUrl = canonicalFeedUrl(slug);
+	const websiteUrl = canonicalWebsiteUrl(slug);
 	const rssAttributes = attributes(rss);
+
+	let websiteLink = firstDirectChild(channel, 'link');
+	if (!websiteLink) websiteLink = appendElement(channel, 'link');
+	setTextValue(websiteLink, websiteUrl);
+	for (const image of directChildren(channel, 'image')) {
+		let imageLink = firstDirectChild(image, 'link');
+		if (!imageLink) imageLink = appendElement(image, 'link');
+		setTextValue(imageLink, websiteUrl);
+	}
 
 	if (!rssAttributes['@_xmlns:atom'] && !rssAttributes['xmlns:atom']) {
 		setAttribute(rss, 'xmlns:atom', 'http://www.w3.org/2005/Atom');

--- a/scripts/podcast-feed.test.mjs
+++ b/scripts/podcast-feed.test.mjs
@@ -1,5 +1,8 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import { XMLParser } from 'fast-xml-parser';
+import { backupPath, verifyObject } from './backup-podcast-r2.mjs';
+import redirects from '../workers/podcast-redirects/index.js';
 import {
 	applyAssetUrls,
 	buildXml,
@@ -53,4 +56,66 @@ test('rewrites Transistor media, auxiliary assets, and episode pages to first-pa
 	assert.match(replacement, /https:\/\/media\.swyx\.io\/podcasts\/fixture-show\/enclosure\//);
 	assert.match(replacement, /https:\/\/media\.swyx\.io\/podcasts\/fixture-show\/auxiliary\//);
 	assert.match(replacement, /#t=0m5s/);
+});
+
+test('canonical website links target the archive without changing episodes or feed URLs', () => {
+	const parser = new XMLParser({ ignoreAttributes: false });
+	for (const previous of [
+		'',
+		'<link>https://temporal.io</link>',
+		'<link>https://swyx.io/podcast/learn-in-podcast/rss.xml</link>'
+	]) {
+		const xml = `<rss version="2.0"><channel>${previous}<image><url>https://media.swyx.io/art.jpg</url><link>https://old.example</link></image><item><guid isPermaLink="false">original-guid</guid><link>https://media.swyx.io/audio.mp3</link><enclosure url="https://media.swyx.io/audio.mp3" length="42" type="audio/mpeg"/></item></channel></rss>`;
+		const document = parseXml(xml);
+		ensureCanonicalFeedLinks(document, 'learn-in-podcast');
+		const channel = parser.parse(buildXml(document)).rss.channel;
+		assert.equal(channel.link, 'https://swyx.io/podcasts#learn-in-podcast');
+		assert.equal(channel.image.link, channel.link);
+		assert.equal(
+			channel['atom:link']['@_href'],
+			'https://swyx.io/podcast/learn-in-podcast/rss.xml'
+		);
+		assert.equal(
+			channel['itunes:new-feed-url'],
+			'https://swyx.io/podcast/learn-in-podcast/rss.xml'
+		);
+		assert.deepEqual(channel.item, parser.parse(xml).rss.channel.item);
+		const once = buildXml(document);
+		ensureCanonicalFeedLinks(document, 'learn-in-podcast');
+		assert.equal(buildXml(document), once);
+	}
+});
+
+test('legacy Mixtape pages permanently redirect to the archive without an open redirect', () => {
+	for (const method of ['GET', 'HEAD']) {
+		for (const path of ['/', '/episodes/example', '/?url=https://evil.example']) {
+			const response = redirects.fetch(new Request(`https://mixtape.swyx.io${path}`, { method }));
+			assert.equal(response.status, 301);
+			assert.equal(response.headers.get('location'), 'https://swyx.io/podcasts#learn-in-podcast');
+		}
+	}
+	assert.equal(redirects.fetch(new Request('https://unknown.example/')).status, 404);
+	assert.equal(
+		redirects.fetch(new Request('https://mixtape.swyx.io/', { method: 'POST' })).status,
+		405
+	);
+});
+
+test('offline backups reject unsafe paths and mismatched remote checksums', () => {
+	assert.equal(backupPath('/tmp/backup', 'feeds/show.xml'), '/tmp/backup/feeds/show.xml');
+	for (const key of ['../escape', '/absolute', 'feeds/../../escape', 'feeds//show.xml']) {
+		assert.throws(() => backupPath('/tmp/backup', key));
+	}
+	const actual = { size: 42, md5: 'a'.repeat(32), sha256: 'b'.repeat(64) };
+	const object = { key: `audio/${'b'.repeat(16)}-episode.mp3`, size: 42, etag: actual.md5 };
+	assert.doesNotThrow(() => verifyObject(object, actual));
+	assert.throws(() => verifyObject(object, { ...actual, size: 41 }), /Size mismatch/);
+	assert.throws(
+		() => verifyObject(object, { ...actual, md5: 'c'.repeat(32) }),
+		/ETag\/MD5 mismatch/
+	);
+	assert.throws(
+		() => verifyObject(object, { ...actual, sha256: 'c'.repeat(64) }),
+		/SHA-256 mismatch/
+	);
 });

--- a/workers/podcast-redirects/index.js
+++ b/workers/podcast-redirects/index.js
@@ -1,0 +1,23 @@
+const ARCHIVE = 'https://swyx.io/podcasts#learn-in-podcast';
+
+export default {
+	/** @param {Request} request */
+	fetch(request) {
+		if (new URL(request.url).hostname !== 'mixtape.swyx.io') {
+			return new Response('Not found', { status: 404 });
+		}
+		if (!['GET', 'HEAD'].includes(request.method)) {
+			return new Response('Method not allowed', {
+				status: 405,
+				headers: { Allow: 'GET, HEAD' }
+			});
+		}
+		return new Response(null, {
+			status: 301,
+			headers: {
+				Location: ARCHIVE,
+				'Cache-Control': 'public, max-age=3600'
+			}
+		});
+	}
+};

--- a/wrangler.podcast-redirects.toml
+++ b/wrangler.podcast-redirects.toml
@@ -1,0 +1,10 @@
+name = "swyxdotio-podcast-redirects"
+account_id = "2d017c943ff16e4c52783635ef05e535"
+main = "workers/podcast-redirects/index.js"
+compatibility_date = "2026-08-25"
+workers_dev = false
+preview_urls = false
+
+[[routes]]
+pattern = "mixtape.swyx.io"
+custom_domain = true


### PR DESCRIPTION
## Changes

- Point generated RSS website links at the corresponding swyx.io archive sections while preserving feed URLs and every episode item.
- Add an isolated Mixtape legacy-host 301 Worker and Custom Domain configuration; the main website is not redeployed.
- Add streaming, resumable offline R2 snapshot backup with remote checksum validation and SHA256SUMS.
- Document the separate Transistor-owned website redirect and analytics steps.

## Verification

- 6 focused podcast tests pass.
- Svelte check: zero errors or warnings.
- Redirect Worker deployment dry-run passes.
- Repair candidates for all three real feeds preserve every parsed episode item.
- Completed the 689-object, 21.80 GB offline backup and independently reread every file to verify all SHA-256s. No media or private draft metadata is committed.

## Rollout

Cloudflare authentication and browser control were unavailable after a Mac restart. This PR does not itself deploy the Worker or mutate the live R2 feeds. Those operations still require restored authentication, conditional feed writes, and live DNS/HTTP checks. Transistor website redirects and analytics exports also remain pending browser recovery.
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/swyxio/swyxdotio/pull/556?analyze=true)

<a href="https://staging.itsdev.in/review/swyxio/swyxdotio/pull/556" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-staging-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-staging-light.svg?v=3" alt="Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/swyxio/swyxdotio/pull/556" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->