### PR TITLE
Finish legacy podcast website redirects

### DIFF
--- a/docs/podcast-transistor-migration.md
+++ b/docs/podcast-transistor-migration.md
@@ -51,9 +51,15 @@ resume. Keep the directory private because it includes unpublished drafts and
 administrative metadata. This backs up the current R2 inventory, not the
 missing original Transistor staging manifests or analytics exports.
 
-The dedicated `wrangler.podcast-redirects.toml` deploy target restores
-`mixtape.swyx.io` as a Cloudflare Custom Domain and sends all legacy website
-paths to the Mixtape archive. It does not redeploy the main website:
+The dedicated `wrangler.podcast-redirects.toml` deploy target serves three
+Cloudflare Custom Domains and sends every legacy website path to its matching
+archive. It does not redeploy the main website:
+
+| Transistor website | Owned redirect domain | Archive section |
+| --- | --- | --- |
+| `swyx.transistor.fm` | `mixtape.swyx.io` | `/podcasts#learn-in-podcast` |
+| `temporal.transistor.fm` | `temporal.swyx.io` | `/podcasts#the-temporal-podcast` |
+| `careerchats.transistor.fm` | `careerchats.swyx.io` | `/podcasts#career-chats` |
 
 ```sh
 npx wrangler deploy --config wrangler.podcast-redirects.toml
@@ -61,8 +67,13 @@ npx wrangler deploy --config wrangler.podcast-redirects.toml
 
 Code, deployment, and live DNS/HTTP verification are separate steps. The
 Transistor-owned `temporal.transistor.fm` and `careerchats.transistor.fm`
-hostnames cannot be configured in our Cloudflare zone; their website redirect
-behavior must be configured in Transistor or arranged with Transistor support.
+hostnames cannot be configured in our Cloudflare zone. After deploying and
+verifying the owned domains, use each show's **Website > URL** settings to set
+the matching custom domain and enable **Redirect all requests to your custom
+domain**. Verify the full redirect chain, including an episode path.
+Transistor's documentation guarantees RSS redirects after cancellation, but
+does not explicitly guarantee website redirects; confirm their retention with
+support before treating the provider-owned website addresses as permanent.
 Do not substitute a JavaScript redirect for a durable provider-level 301 after
 account cancellation. Website redirects are separate from the three existing
 RSS redirects.

--- a/scripts/podcast-feed.test.mjs
+++ b/scripts/podcast-feed.test.mjs
@@ -86,19 +86,22 @@ test('canonical website links target the archive without changing episodes or fe
 	}
 });
 
-test('legacy Mixtape pages permanently redirect to the archive without an open redirect', () => {
-	for (const method of ['GET', 'HEAD']) {
-		for (const path of ['/', '/episodes/example', '/?url=https://evil.example']) {
-			const response = redirects.fetch(new Request(`https://mixtape.swyx.io${path}`, { method }));
-			assert.equal(response.status, 301);
-			assert.equal(response.headers.get('location'), 'https://swyx.io/podcasts#learn-in-podcast');
+test('legacy podcast pages permanently redirect to their own archive without an open redirect', () => {
+	for (const [host, slug] of [
+		['mixtape.swyx.io', 'learn-in-podcast'],
+		['temporal.swyx.io', 'the-temporal-podcast'],
+		['careerchats.swyx.io', 'career-chats']
+	]) {
+		for (const method of ['GET', 'HEAD']) {
+			for (const path of ['/', '/episodes/example', '/?url=https://evil.example']) {
+				const response = redirects.fetch(new Request(`https://${host}${path}`, { method }));
+				assert.equal(response.status, 301);
+				assert.equal(response.headers.get('location'), `https://swyx.io/podcasts#${slug}`);
+			}
 		}
+		assert.equal(redirects.fetch(new Request(`https://${host}/`, { method: 'POST' })).status, 405);
 	}
 	assert.equal(redirects.fetch(new Request('https://unknown.example/')).status, 404);
-	assert.equal(
-		redirects.fetch(new Request('https://mixtape.swyx.io/', { method: 'POST' })).status,
-		405
-	);
 });
 
 test('offline backups reject unsafe paths and mismatched remote checksums', () => {

--- a/workers/podcast-redirects/index.js
+++ b/workers/podcast-redirects/index.js
@@ -1,9 +1,14 @@
-const ARCHIVE = 'https://swyx.io/podcasts#learn-in-podcast';
+const ARCHIVES = new Map([
+	['mixtape.swyx.io', 'https://swyx.io/podcasts#learn-in-podcast'],
+	['temporal.swyx.io', 'https://swyx.io/podcasts#the-temporal-podcast'],
+	['careerchats.swyx.io', 'https://swyx.io/podcasts#career-chats']
+]);
 
 export default {
 	/** @param {Request} request */
 	fetch(request) {
-		if (new URL(request.url).hostname !== 'mixtape.swyx.io') {
+		const archive = ARCHIVES.get(new URL(request.url).hostname);
+		if (!archive) {
 			return new Response('Not found', { status: 404 });
 		}
 		if (!['GET', 'HEAD'].includes(request.method)) {
@@ -15,7 +20,7 @@ export default {
 		return new Response(null, {
 			status: 301,
 			headers: {
-				Location: ARCHIVE,
+				Location: archive,
 				'Cache-Control': 'public, max-age=3600'
 			}
 		});

--- a/wrangler.podcast-redirects.toml
+++ b/wrangler.podcast-redirects.toml
@@ -8,3 +8,11 @@ preview_urls = false
 [[routes]]
 pattern = "mixtape.swyx.io"
 custom_domain = true
+
+[[routes]]
+pattern = "temporal.swyx.io"
+custom_domain = true
+
+[[routes]]
+pattern = "careerchats.swyx.io"
+custom_domain = true


### PR DESCRIPTION
## Changes
- Extend the isolated podcast redirect Worker to temporal.swyx.io and careerchats.swyx.io, routing each hostname and legacy path to its own archive section.
- Preserve Mixtape behavior, reject unknown hosts, and document Transistor's native custom-domain redirect setup.
- Keep website-redirect retention after cancellation explicitly separate from the documented permanent RSS redirects.

## Verification
- Six focused podcast tests passed, including all three hosts, GET/HEAD, legacy paths, and open-redirect rejection.
- Svelte check: zero errors and warnings.
- Wrangler deployment dry-run passed; no main-site Worker deployment is required.

## Rollout
Deploy this Worker and verify the owned hostnames before saving the two provider-side custom-domain redirects. Confirm website-redirect retention with Transistor support. Private analytics exports are backed up separately and are not included in this PR.
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/swyxio/swyxdotio/pull/557?analyze=true)

<a href="https://staging.itsdev.in/review/swyxio/swyxdotio/pull/557" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-staging-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-staging-light.svg?v=3" alt="Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/swyxio/swyxdotio/pull/557" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->