### PR TITLE
Avoid unregistered talk keys in Ideas view-count batches

### DIFF
--- a/src/routes/ideas/+page.svelte
+++ b/src/routes/ideas/+page.svelte
@@ -261,7 +261,8 @@
 		const keys = [
 			...new Set(
 				visibleItems
-					.filter((item) => !isExternalItem(item))
+					// Speaking entries without a video are still not registered article counters.
+					.filter((item) => item.type === 'blog')
 					.map((item) => item.slug)
 					.filter((slug) => slug && !requestedReadKeys.has(slug))
 			)

--- a/tests/ideas-library.test.mjs
+++ b/tests/ideas-library.test.mjs
@@ -186,3 +186,18 @@ test('Ideas uses a compact masthead, readable archive type, and touch-sized cont
 	assert.match(source, /class="entry-category" title=\{item.venues\}>\{item.category\}/);
 	assert.match(source, /class="ideas-stage"/);
 });
+
+test('archive view-count batches include only registered article content', async () => {
+	const source = await readFile(
+		new URL('../src/routes/ideas/+page.svelte', import.meta.url),
+		'utf8'
+	);
+	const loader = source.slice(
+		source.indexOf('async function loadReadCounts('),
+		source.indexOf('function toggleReadCountVisibility(')
+	);
+	// A talk with no video (for example, fullstack-heaps) is not an article.
+	// Including it makes the read-count endpoint reject the whole batch.
+	assert.match(loader, /\.filter\(\(item\) => item\.type === 'blog'\)/);
+	assert.doesNotMatch(loader, /!isExternalItem\(item\)/);
+});


### PR DESCRIPTION
## Fix

Production verification of #560 found that the older `fullstack-heaps` talk has no video URL, so the archive treated it as an article when loading view counts. Its unregistered counter key caused the API to reject the entire batch with a 404.

Request view counts only for first-party `type: 'blog'` entries. All 630 library entries remain visible; no API admission, privacy, or counting-backend changes.

## Verification

- Added a regression guard for the article-only request selection.
- All 436 Node tests pass on the current master plus this fix, including the separately merged portfolio update.
- Svelte check: zero errors and warnings; production build passes.
- Verified all 432 public article keys against the production batch API; the unrecorded talk is the sole invalid key in the prior selection.

Follow-up deployment and full-scroll browser verification are part of the user-approved publishing task.
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/swyxio/swyxdotio/pull/562?analyze=true)

<a href="https://staging.itsdev.in/review/swyxio/swyxdotio/pull/562" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-staging-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-staging-light.svg?v=3" alt="Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/swyxio/swyxdotio/pull/562" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->