### PR TITLE
Restore portfolio tiers and expand public financial coverage

### DIFF
--- a/docs/portfolio-research.md
+++ b/docs/portfolio-research.md
@@ -1,0 +1,313 @@
+# Portfolio research follow-up — 2026-08-26
+
+Restores the original four editorial tiers and expands the public valuation search. No private investment records were used. Company announcements and dated press/database marks are distinguished from filing-derived estimates. Raised amounts and cumulative funding are separate from valuations; acquisition prices are excluded from the valuation column. Historical values are not current marks or the value of swyx's holdings.
+
+## Chroma
+
+Added the $75M April 2023 seed valuation. Corroborated by [CB Insights](https://www.cbinsights.com/company/chroma-6/financials) and [the original reporter, Stephanie Palazzolo](https://www.linkedin.com/posts/stephanie-palazzolo_vector-database-chroma-scored-18-million-activity-7049789226158018560-Vvvm).
+
+## Railway
+
+Forge lists $409.01M post-money for Series B and B-1 on Jan 22, 2026. Footnote 3 explicitly calls post-money valuations estimates based on company-submitted Certificates of Incorporations (COIs). This is not a company-announced valuation or the daily Forge Price. Forge shows $77.53M B plus $12.5M B-1; the company announced a $100M total round. Do not sum Forge series rows to substitute for the announced financing amount.
+
+- Valuation: [Forge: Railway funding rounds and valuation](https://forgeglobal.com/railway_stock/).
+- Funding: [Railway raises $100M Series B](https://blog.railway.com/p/series-b).
+- [forgeglobal.com](https://forgeglobal.com/railway_stock/).
+- [blog.railway.com](https://blog.railway.com/p/series-b).
+- [www.cbinsights.com](https://www.cbinsights.com/company/railway/financials).
+- [www.prnewswire.com](https://www.prnewswire.com/news-releases/railway-raises-100-million-series-b-as-ai-pushes-todays-cloud-infrastructure-past-its-limits-302667768.html).
+
+## Artificial Analysis
+
+Latent Space's Jan 8, 2026 founder episode introduction states the company raised a full seed round from Nat Friedman and Daniel Gross after AI Grant; neither amount nor closing date is disclosed. Thus the older $250K AI Grant should not be labeled the latest financing. Checked exact-name funding/valuation searches, CB Insights, Dealroom, and founder interview. No publicly sourced priced valuation found. Dealroom's $1–2M enterprise-value range is a modeled estimate and was rejected.
+
+- Funding: [Latent Space: Artificial Analysis](https://www.latent.space/p/artificialanalysis).
+- [www.latent.space](https://www.latent.space/p/artificialanalysis).
+- [www.cbinsights.com](https://www.cbinsights.com/company/artificial-analysis/financials).
+- [app.dealroom.co](https://app.dealroom.co/companies/artificial_analysis).
+
+## E2B
+
+Aaron Harris's dated PostRound investor newsletter explicitly reports E2B's $21M Series A at $106M on Jul 28, 2025, matching CEO Vasek Mlejnsky, e2b.dev, and lead Insight Partners. The article does not name its underlying database or explicitly state pre-/post-money basis. Premier Alternatives instead lists $104M as of Jul 28, 2025, labeled Last priced round, but gives no underlying provenance and a conflicting total-raised figure. Prefer the named investor report, retain this discrepancy in audit notes, and do not imply company confirmation. Official round announcement and CB Insights confirm $21M Series A date but do not disclose valuation. No usable public Forge or PitchBook valuation found through targeted searches.
+
+- Valuation: [Aaron Harris: Series A activity, week of July 28, 2025](https://postround.substack.com/p/series-a-activity-week-of-july-28).
+- Funding: [E2B: We raised $21M to give Fortune 100 cloud for AI agents](https://changelog.e2b.dev/blog/series-a).
+- [postround.substack.com](https://postround.substack.com/p/series-a-activity-week-of-july-28).
+- [changelog.e2b.dev](https://changelog.e2b.dev/blog/series-a).
+- [www.prnewswire.com](https://www.prnewswire.com/news-releases/e2b-raises-a-21m-series-a-to-offer-cloud-for-ai-agents-to-fortune-100-302514540.html).
+- [www.cbinsights.com](https://www.cbinsights.com/company/e2b/financials).
+- [www.premieralts.com](https://www.premieralts.com/companies/e2b/valuation).
+
+## Resend
+
+Publicly indexed CB Insights table explicitly pairs Apr 20, 2023 Angel round with $25M valuation; headline also states April 2023 $25M. Pre-/post-money basis is not exposed. Direct page requests returned 403, but the indexed page showed the full dated table. Historical mark predates Jul 2023 seed and Dec 2024 Series A; no later valuation verified. Do not label $25M as valuation of the $18M Series A. Checked official seed and Series A announcements, CB Insights, Hiive, and targeted Forge/PitchBook queries. Rejected generic speculative valuations.
+
+- Valuation: [CB Insights: Resend financials](https://www.cbinsights.com/company/resend/financials).
+- Funding: [Resend raises $18M Series A](https://resend.com/blog/series-a).
+- [www.cbinsights.com](https://www.cbinsights.com/company/resend/financials).
+- [resend.com](https://resend.com/blog/series-a).
+- [resend.com](https://resend.com/blog/resend-raises-3m-seed-round).
+- [www.hiive.com](https://www.hiive.com/securities/resend-stock).
+
+## Conductor
+
+Official announcement explicitly states $22M Series A from Spark and Matrix, with no valuation. Targeted searches used conductor.build, founders Charlie Holtz/Jackson de Campos, and legal name Melty Labs. Do not use the $525M valuation of the unrelated SEO-marketing company Conductor. Dealroom's $88–132M enterprise-value estimate is modeled and was rejected.
+
+- Funding: [Conductor’s Series A](https://www.conductor.build/blog/series-a).
+- [www.conductor.build](https://www.conductor.build/blog/series-a).
+- [app.dealroom.co](https://app.dealroom.co/companies/conductor_6).
+
+## Restate
+
+Company announcement dated Jun 10, 2024 explicitly discloses $7M seed. TechCrunch and CB Insights use Jun 12, 2024 press date; official date retained. Checked official announcement, TechCrunch, CB Insights, Dealroom, and exact post-money/valuation searches; no numeric valuation verified. Rejected modeled Dealroom $28–42M range.
+
+- Funding: [Announcing Restate 1.0, Restate Cloud, and our seed funding round](https://restate.dev/blog/announcing-restate-1.0-restate-cloud-and-our-seed-funding-round).
+- [restate.dev](https://restate.dev/blog/announcing-restate-1.0-restate-cloud-and-our-seed-funding-round).
+- [techcrunch.com](https://techcrunch.com/2024/06/12/restate-raises-7m-for-its-lightweight-workflows-as-code-platform/).
+- [www.cbinsights.com](https://www.cbinsights.com/company/restate/financials).
+
+## Datalab
+
+Original reporting by Paul Sawers dated Jun 17, 2025 says Datalab announced $3.5M seed led by Pebblebed. This is the OCR/document AI company founded by Vik Paruchuri and Sandy Kwon, not unrelated Datalab businesses. Founder had already referred to the seed round in an earlier hiring post; date is public amount-announcement date, not a claim about closing day. Exact-name and founder-specific funding/valuation/post-money searches produced no verified valuation.
+
+- Funding: [Paul Sawers: Datalab develops small AI models to power document intelligence in the enterprise](https://www.forkable.io/p/datalab-develops-small-ai-models).
+- [www.forkable.io](https://www.forkable.io/p/datalab-develops-small-ai-models).
+- [www.linkedin.com](https://www.linkedin.com/posts/vikparuchuri_im-looking-for-a-head-of-business-operations-activity-7290051594551709698-rCZ_).
+
+## Brightwave
+
+Company-issued Business Wire release syndicated by FinancialContent explicitly says $15M Series A closed, bringing total funding to $21M. CB Insights and TechCrunch corroborate. Checked official release, original press coverage, CB Insights, Seedtable and exact post-money searches. Seedtable leaves pre-/post-money fields blank. No numeric valuation verified; generic models rejected.
+
+- Funding: [Brightwave secures $15M Series A to scale AI-powered financial research platform](https://markets.financialcontent.com/stocks/article/bizwire-2024-10-29-brightwave-secures-15m-series-a-to-scale-ai-powered-financial-research-platform).
+- [markets.financialcontent.com](https://markets.financialcontent.com/stocks/article/bizwire-2024-10-29-brightwave-secures-15m-series-a-to-scale-ai-powered-financial-research-platform).
+- [techcrunch.com](https://techcrunch.com/2024/10/29/brightwaves-ai-agent-helps-asset-managers-find-signal-and-its-fundraising-fast/).
+- [www.cbinsights.com](https://www.cbinsights.com/company/brightwave-2/financials).
+- [seedtable.com](https://seedtable.com/companies/brightwave/funding-rounds/series-a-2024).
+
+## Quadratic
+
+Official announcement verifies $5.6M Seed announced Apr 2, 2024. A later Aug 2025 financing appears on two aggregators, but their dates and amounts conflict and no primary or reputable press corroboration was found; therefore 2024 is latest VERIFIED amount, not a claim no later funding occurred. Premier Alternatives displays $25.4M as of Aug 29, 2025 and $5.4M seed, labeled Last priced round. Its history table does not expose the actual post-money datum/provenance. Employbl/Diffbot instead says $5.5M Aug 31, 2025 and contains duplicated/misdated older rounds. Candidate withheld. Searched exact Quadratic spreadsheet/David Kircos/quadratichq funding, valuation, post-money, dates, plus CB Insights/PitchBook/Dealroom. Avoid unrelated Quadratic 3D and Quadric chip company.
+
+- Funding: [Announcing our $5.6M seed round and Quadratic Teams](https://www.quadratichq.com/blog/announcing-our-seed-round-funding-and-quadratic-teams).
+- [www.quadratichq.com](https://www.quadratichq.com/blog/announcing-our-seed-round-funding-and-quadratic-teams).
+- [techcrunch.com](https://techcrunch.com/2024/04/02/quadratic-is-reimagining-the-spreadsheet-with-a-focus-on-data/).
+- [www.premieralts.com](https://www.premieralts.com/companies/quadratic/valuation).
+- [www.employbl.com](https://www.employbl.com/companies/quadratic).
+- [app.dealroom.co](https://app.dealroom.co/companies/quadratic_2).
+
+## Val Town
+
+Founder Steve Krouse's official post says $5.5M seed led by Accel, following $1.5M pre-seed in Aug 2022. Total funding $7M is not the latest round amount. Checked official founder post, Accel, CB Insights/Dealroom, and exact valuation/post-money queries. Public database rounds are stale versus the company announcement. No valuation verified.
+
+- Funding: [Val Town’s seed round](https://blog.val.town/blog/seed/).
+- [blog.val.town](https://blog.val.town/blog/seed/).
+- [www.accel.com](https://www.accel.com/companies/val-town).
+- [www.cbinsights.com](https://www.cbinsights.com/company/val-town/financials).
+
+## Preference Model
+
+No publicly quantified financing or valuation located. Correct entity is preferencemodel.com, founded by Jennifer Zhou and Ning Cao. Public recruiting profile lists South Park Commons and Scale Angels Fund as investors, but no amount, stage, or date. Searched exact company phrase, founder names, domain plus funding/raised/valuation and database terms. Most generic search results concern mathematical preference models or unrelated founders' liked posts. Do not infer funding or valuation from accelerator terms or investors.
+
+- [standout.work](https://standout.work/companies/42f98132-8311-401a-970a-b21cddc08b41).
+- [www.linkedin.com](https://www.linkedin.com/in/jennife-).
+- [www.startuphub.ai](https://www.startuphub.ai/startups/preferencemodel-com).
+
+## Littlebird
+
+Official company announcement is dated Mar 22, 2026 and states $11M led by Lotus Studio. TechCrunch reported Mar 23, and PRNewswire carried Mar 24; use official announcement date. Dealroom calls the round Seed. Checked company release, TechCrunch, Dealroom, TipRanks and exact valuation queries. No numeric valuation verified. Do not confuse with the unrelated Little Bird acquired by Sprinklr in 2016.
+
+- Funding: [Littlebird raises $11M to build the first full-context AI](https://littlebird.ai/blog/littlebird-raises-11m-to-build-the-first-full-context-ai).
+- [littlebird.ai](https://littlebird.ai/blog/littlebird-raises-11m-to-build-the-first-full-context-ai).
+- [techcrunch.com](https://techcrunch.com/2026/03/23/littlebird-raises-11m-to-capture-context-from-your-computer-so-you-can-query-your-data/).
+- [dealroom.co](https://dealroom.co/companies/littlebird/).
+- [www.tipranks.com](https://www.tipranks.com/private-companies/littlebird).
+
+## Clarify
+
+Company June 25, 2025 release states $22.5M TOTAL funding across seed and Series A, not a $22.5M round. CB Insights identifies latest disclosed single round as $15M Series A. GeekWire Jul 21, 2026 reports additional funding alongside Seam AI joining Clarify, amount undisclosed. Thus $15M is latest disclosed round amount, not newest financing. Checked primary announcement, GeekWire, CB Insights and founder/company-specific valuation queries. No valuation verified. Avoid unrelated healthcare company Clarify Health.
+
+- Funding: [CB Insights: Clarify financials](https://www.cbinsights.com/company/clarify-4/financials).
+- [www.clarify.ai](https://www.clarify.ai/blog/series-a).
+- [www.cbinsights.com](https://www.cbinsights.com/company/clarify-4/financials).
+- [www.geekwire.com](https://www.geekwire.com/2026/seattles-clarify-acquires-s-f-startup-seam-ai-joining-forces-to-challenge-crm-stalwarts/).
+- [www.ascend.vc](https://www.ascend.vc/blog/investing-in-clarify).
+
+## Phonic
+
+Company press release verifies $4M Apr 3, 2025; TechCrunch confirms Seed led by Lux. The announcement identifies phonic.co and founders Moin Nadeem and Nikhil Murthy. The current phonic.ai/company page also identifies both founders; the portfolio keeps that verified current website. TipRanks lists $4M on both Apr 3 and May 3, 2025 and $8M total, but no source supports a second round; treat as possible duplicate and use primary announcement. Nathan Benaich's May 2025 funding roundup explicitly says valuation not disclosed.
+
+- Funding: [Phonic launches speech-to-speech platform and announces $4M funding](https://www.prnewswire.com/news-releases/phonic-launches-end-to-end-speech-to-speech-platform-for-building-reliable-voice-agents-announces-4m-funding-raise-302419143.html).
+- [www.prnewswire.com](https://www.prnewswire.com/news-releases/phonic-launches-end-to-end-speech-to-speech-platform-for-building-reliable-voice-agents-announces-4m-funding-raise-302419143.html).
+- [techcrunch.com](https://techcrunch.com/2025/04/03/end-to-end-voice-ai-solution-phonic-gets-backing-from-lux/).
+- [www.tipranks.com](https://www.tipranks.com/private-companies/phonic).
+- [nathanbenaich.substack.com](https://nathanbenaich.substack.com/p/state-of-ai-may-2025-newsletter).
+
+## Keycard
+
+Investor Boldstart's Oct 21, 2025 announcement separates $8M inception round and $30M Series A led by Acrew. $38M is cumulative funding, not the Series A amount. Original Alex Konrad reporting, CB Insights, Sacra and Caplight do not expose a valuation. Premier Alternatives' $145M Jul 22, 2025 figure is labeled Market implied, has no funding rounds/provenance, and is excluded. Dealroom's modeled enterprise-value range is also excluded.
+
+- Funding: [Keycard: Solving the AI agent identity and access problem](https://boldstart.vc/news/keycard-solving-the-ai-agent-identity-and-access-problem-welcome-to-boldstart/).
+- [boldstart.vc](https://boldstart.vc/news/keycard-solving-the-ai-agent-identity-and-access-problem-welcome-to-boldstart/).
+- [www.upstartsmedia.com](https://www.upstartsmedia.com/p/this-startup-raised-38m-to-secure).
+- [www.cbinsights.com](https://www.cbinsights.com/company/keycard/financials).
+- [sacra.com](https://sacra.com/c/keycard/).
+- [www.caplight.com](https://www.caplight.com/company/keycard).
+- [www.premieralts.com](https://www.premieralts.com/companies/keycard-labs/valuation).
+
+## Confident Security
+
+TechCrunch original reporting dates the $4.2M seed to Jul 17, 2025. Later aggregators use Jul 22 republication dates; original date retained. Checked original press, Mandos, Premier Alternatives, Seedtable, Dealroom and exact valuation queries. No numeric valuation verified. Seedtable ownership estimates are explicitly modeled, not a filed cap table; rejected.
+
+- Funding: [Confident Security, the Signal for AI, comes out of stealth with $4.2M](https://techcrunch.com/2025/07/17/confident-security-the-signal-for-ai-comes-out-of-stealth-with-4-2m/).
+- [techcrunch.com](https://techcrunch.com/2025/07/17/confident-security-the-signal-for-ai-comes-out-of-stealth-with-4-2m/).
+- [mandos.io](https://mandos.io/data/companies/confident-security).
+- [www.premieralts.com](https://www.premieralts.com/companies/confident-security).
+- [seedtable.com](https://seedtable.com/companies/confident-security).
+
+## Wordware
+
+Company blog dated Nov 25, 2024 confirms $30M Seed led by Spark. CB Insights uses Nov 21, 2024 announcement date. This is a Seed despite some aggregators calling it Series A. Newcomer Sep 20, 2024 reporting says Wordware received offers including one at $140M post-money; that is a proposed term, not a verified completed round, and was excluded. Premier Alternatives shows $140.2M Oct 2, 2024 with no underlying provenance and inconsistent round labeling; insufficient corroboration for accepted valuation. Sacra/CB Insights/company announcements do not disclose final valuation; targeted Forge/PitchBook/PostRound searches found none.
+
+- Funding: [Wordware raises $30M seed round](https://blog.wordware.ai/seed-round).
+- [blog.wordware.ai](https://blog.wordware.ai/seed-round).
+- [www.wordware.ai](https://www.wordware.ai/announcement).
+- [www.cbinsights.com](https://www.cbinsights.com/company/wordware-ai/financials).
+- [sacra.com](https://sacra.com/c/wordware/).
+- [www.newcomer.co](https://www.newcomer.co/p/yc-embraces-missilestan-goes-big).
+- [www.premieralts.com](https://www.premieralts.com/companies/wordware/valuation).
+
+## Lightweight Labs
+
+Exact Lightweight Labs / David Yang / instabooks.io searches and official about page confirm identity; no trustworthy public financing amount or valuation found.
+
+- [About — Instabooks](https://instabooks.io/about).
+
+## Polyhive
+
+CBInsights identifies Mythos Ventures investment but no amount/date/valuation. SOMA Fellows F23 page identifies AI3D company. Rejected unrelated packaging business Polyhive.com and other firms' rounds on shared lists.
+
+- [Polyhive — CBInsights profile](https://www.cbinsights.com/company/polyhive).
+- [Soma Fellows F23 Demo Day](https://www.soma-demoday.com/).
+
+## Sailplane
+
+True Ventures official portfolio/job board confirms Seed stage and Khosla/True backers. No reliable disclosed amount/valuation. Rejected Highperformr $5.5M assertion because company description is wrong (product-led sales rather than Sam Ramji's autonomous infrastructure).
+
+- [Sailplane — True Ventures](https://jobs.trueventures.com/companies/sailplane).
+- [Sailplane Principal Engineer — True Ventures](https://jobs.trueventures.com/companies/sailplane/jobs/68687692-principal-engineer).
+
+## Morph
+
+Exact morph.so record on Dealroom says no known external funding; no public amount found. Rejected MorphL2/blockchain $125M and morphllm figures. Caplight matches URL but description wrong (brain-computer interface).
+
+- [Morph Labs — Dealroom](https://app.dealroom.co/companies/morph_labs).
+
+## Fireproof Storage
+
+CBInsights analyst briefing submitted lists $1.71M last raised and July31 2024 pre-seed announcement. Caplight independently lists $1.7M pre-seed July31 2024. No valuation disclosed.
+
+- Funding: [Fireproof Storage — CBInsights](https://www.cbinsights.com/company/fireproof-storage).
+- [Fireproof funding rounds — Caplight](https://www.caplight.com/company/fireproof).
+
+## Arcjet
+
+Company announcement explicitly $8.3M Series A; company's2025 recap corroborates. Dealroom $33–50M enterprise-value range excluded as modeled. CryptoRank placeholder $50K excluded.
+
+- Funding: [Introducing Arcjet's local AI security model + announcing Series A funding](https://blog.arcjet.com/introducing-arcjets-local-ai-security-model-announcing-series-a-funding/).
+
+## Cosine
+
+Mike Butcher June8 2026 direct interview with co-founder Yang Li states $8M raised so far, NOT an $8M new round. Winfred incorrectly appears to count it as an additional8M round ($10.5M total). No verified valuation. Further historical search found explicit CBInsights15M Apr2023 seed valuation under original company Buildt. Later2024 seed and2026 grant exist but no newer disclosed valuation.
+
+- Valuation: [Cosine Stock Price, Funding, Valuation — CBInsights](https://www.cbinsights.com/company/buildt/financials).
+- Funding: [Cosine AI recruits corporate heavyweights to build sovereign UK frontier AI model](https://pathfounders.com/p/cosine-ai-recruits-corporate-heavyweights-to-build-sovereign).
+
+## Responsive
+
+Exact responsive.dev entity and founders Rohan Desai/John Roesler searched; only StartupSeeker total4.9m no round dates or primary source. Do not ship unverified candidate. Materialized View confirms investment not amount. Rejected RFPIO/Responsive RFP and Responsive Capital namesakes.
+
+- [Materialized View Capital portfolio](https://materializedview.capital/).
+- [Responsive documentation](https://docs.responsive.dev/).
+
+## Budibase
+
+Company primary announcement Nov4 explicitly7M SeedII,total9.25M; CBInsights dates event Sep7. Use announcement date and stage as company. Dealroom28–42m modeled range and Checkthat estimate excluded.
+
+- Funding: [Budibase raises $7M to help every company build their own tools](https://budibase.com/blog/updates/budibase-raises-7m-to-help-every-company-on-the-planet-build-their-own-tools/).
+
+## 100ms.live
+
+No public valuation found after dedicated valued/valuation queries and CBInsights financials; total24.5M and SeriesA20M explicit. Exact date is TechCrunch publication March10 Pacific,March11 elsewhere. Dealroom80–120M range is a modeled enterprise value, excluded.
+
+- Funding: [100ms secures $20M to power live video apps](https://techcrunch.com/2022/03/10/100ms-secures-20m-to-power-next-generation-of-live-video-apps/).
+
+## Expand.ai
+
+YC-backed Tim Suchanek company found; Crunchbase round amount hidden, Dealroom125k only part of YC standard deal and StartupSeeker500k lack public deal confirmation. Avoid translating YC standard terms into exact valuation or new-round facts. GetLatka990k entirely estimated and excluded.
+
+- [expand.ai — Crunchbase](https://www.crunchbase.com/organization/expand-ai).
+- [expand.ai — Dealroom](https://app.dealroom.co/companies/expand_ai).
+
+## Catamaran Research
+
+Exact name and Derek Zaw searches did not establish public financing. A Wellfound Catamaran Research lists Alexis De Boeck/Singapore; not substituted without founder match. Other results are actual marine vessels. Remains no reliable public data found.
+
+## Astral
+
+Company March19 2026 acquisition announcement explicitly confirms later SeriesA ledAccel and SeriesB led a16z but no terms. Never represent4M as total raised/latest completed round. No substantiated acquisition price found; exclude modeled40M from UpsideList and unrelated Astral listed company.
+
+- Funding: [Announcing Astral, the company behind Ruff](https://astral.sh/blog/announcing-astral-the-company-behind-ruff).
+- [Astral to join OpenAI](https://astral.sh/blog/openai).
+
+## Gabber.dev
+
+Co-founder Jack Dwyer's public LinkedIn confirms team joined LiveKit, but deal terms not disclosed. Dealroom no known external funding is incomplete because founder recap says venture funding; don't say unfunded. Prospeo821328 is automatic revenue multiple, rejected.
+
+- [Jack Dwyer — Gabber joining LiveKit](https://www.linkedin.com/posts/jackndwyer_the-news-is-out-gabber-is-joining-livekit-activity-7419100783738040320-4mKG).
+
+## Brev.dev
+
+CBInsights explicitly shows8.5–10M for Aug24 2021 pre-seed. Source says valuation data can be companies, filings/news, VentureSource or comps models; exact provenance unprovided. Must label database-reported range not exact priced round or exit price. Nvidia July2024 acquisition terms not publicly disclosed.
+
+- Valuation: [Brev Stock Price, Funding, Valuation — CBInsights](https://www.cbinsights.com/company/brevdev/financials).
+
+## Gel / EdgeDB
+
+Primary company press release states15M SeriesA,no valuation. Gel updates corroborate; CBInsights valuation hidden. Do not use15M as valuation or19M cumulative total as latest round. PrivCo public profile shows apparently sample financial tables (380M revenue etc), excluded. Caplight no public valuation.
+
+- Funding: [EdgeDB Raises $15M Series A Round](https://www.prnewswire.com/news-releases/edgedb-raises-15m-series-a-round-to-bring-its-modernized-relational-database-for-cutting-edge-apps-to-the-cloud-301669752.html).
+
+## Dynamic
+
+Newer approx90M acquisition price explicitly CTech and Globes; Architect Partners2025 report also lists90M. Official buyer confirms acquisition/date but no terms. Historical PitchBook explicitly64.3M post-money but deal22.3M conflicts with company's13.5M SeriesA; retain only as research history, do not substitute acquisition price for financing valuation.
+
+- Valuation: [PitchBook Q4 2023 Emerging Tech Indicator, page22](https://files.pitchbook.com/website/files/pdf/Q4_2023_Emerging_Tech_Indicator.pdf#page=22).
+- [Fireblocks buys Israeli crypto wallet co Dynamic](https://en.globes.co.il/en/article-fireblocks-acquires-Israeli-crypto-wallet-co-dynamic-1001524452).
+- [Fireblocks Acquires Dynamic](https://www.fireblocks.com/blog/fireblocks-acquires-dynamic).
+- [2025 Year End Crypto M&A and Financing Report](https://architectpartners.com/wp-content/uploads/2026/01/2025-Year-End-Crypto-MA-and-Financing-Report.pdf).
+
+## Begin.com
+
+Searched exact domain, founders Ryan Block/Brian LeRoux, former Small Wins alias, funding and valuation. Found GC and Slack backing but no reliable amount or valuation. Beware namesake BeginLearning large rounds. Separate fact: Sanity company blog says Begin.com team joined Sanity, but user's original status dead should not be silently replaced by acquisition claim.
+
+- [Begin profile — ParsersVC](https://parsers.vc/startup/begin.com/).
+- [Sanity company blog](https://www.sanity.io/blog?category=company&page=3).
+
+## Dimension.dev
+
+Company event profile direct Dimension.dev/Tejas identity lists350K money raised as ofJan1 2025. Dealroom lists150KJan2023 +200KNov2023 matches350K; use total/dateLabel not claim Jan2025 round. Dealroom800K–1M enterprise-value model excluded. CBInsights dimension-16 financials reports190K Nov7 2023 and340K total (versus TechCrunch350K total). Preserve source-specific figures; no stronger valuation found.
+
+- Funding: [Dimension — TechCrunch Startup Battlefield](https://techcrunch.com/startup-battlefield/company/dimension/).
+- [Dimension — CBInsights financials](https://www.cbinsights.com/company/dimension-16/financials).
+
+## Sphere Semiconductor
+
+Primary investor says12.5M recent financing ledAcme/Future and7.5M formation capital,total20M. Aggregator12M and2026date inconsistent; prefer investor Sep22 2025. Prospeo2.5M modeled valuation and no-funding claim rejected.
+
+- Funding: [Investing in Sphere Semi: Reinventing Analog Chip Design for the AI Era](https://www.constructcap.com/articles/investing-in-sphere-semi-reinventing-analog-chip-design-for-the-ai-era).
+
+## Replay
+
+Exact domain/founder and historical financing search found the company's June13 2023 $13M SeriesA announcement. Dealroom52–78M and Prospeo3.3M are modeled estimates, not priced-round valuations; excluded. Some aggregate pages conflate Replay.io with Replay Technologies; excluded.
+
+- Funding: [Replay for Test Suites: $13M Series A announcement](https://www.replay.io/blog/replay-for-test-suites).

--- a/src/lib/data/portfolio.json
+++ b/src/lib/data/portfolio.json
@@ -15,7 +15,8 @@
 			"sourceTitle": "Temporal raises $300M Series D",
 			"qualifier": "Reported valuation"
 		},
-		"relatedUrl": "/why-temporal"
+		"relatedUrl": "/why-temporal",
+		"tier": "Well known names"
 	},
 	{
 		"id": "cognition",
@@ -33,7 +34,8 @@
 			"sourceTitle": "Cognition: More Devins in More Places",
 			"qualifier": "Post-money"
 		},
-		"relatedUrl": "/cognition"
+		"relatedUrl": "/cognition",
+		"tier": "Well known names"
 	},
 	{
 		"id": "supabase",
@@ -50,7 +52,8 @@
 			"sourceUrl": "https://www.prnewswire.com/news-releases/supabase-raises-500m-at-10-5b-to-accelerate-lead-in-agentic-infrastructure-302791787.html",
 			"sourceTitle": "Supabase raises $500M at $10.5B",
 			"qualifier": "Post-money"
-		}
+		},
+		"tier": "Well known names"
 	},
 	{
 		"id": "railway",
@@ -61,7 +64,25 @@
 		"status": "current",
 		"logo": "/portfolio/railway.png",
 		"logoSource": "https://railway.com/apple-touch-icon.png",
-		"valuation": null
+		"valuation": {
+			"amountUsd": 409010000,
+			"date": "2026-01-22",
+			"stage": "Series B",
+			"kind": "filing-derived",
+			"prefix": "≈",
+			"qualifier": "Filing-derived estimate",
+			"sourceUrl": "https://forgeglobal.com/railway_stock/",
+			"sourceTitle": "Forge: Railway funding rounds and valuation"
+		},
+		"tier": "Well known names",
+		"funding": {
+			"amountUsd": 100000000,
+			"date": "2026-01-22",
+			"stage": "Series B",
+			"kind": "round",
+			"sourceUrl": "https://blog.railway.com/p/series-b",
+			"sourceTitle": "Railway raises $100M Series B"
+		}
 	},
 	{
 		"id": "workos",
@@ -78,7 +99,8 @@
 			"sourceUrl": "https://workos.com/blog/series-c",
 			"sourceTitle": "WorkOS raises $100M Series C, hits $2B valuation",
 			"qualifier": "Reported valuation"
-		}
+		},
+		"tier": "Well known names"
 	},
 	{
 		"id": "matx",
@@ -97,7 +119,8 @@
 			"qualifier": "Series A · newer mark undisclosed",
 			"prefix": ">"
 		},
-		"relatedUrl": "https://www.youtube.com/watch?v=qvrdCpLPbuQ"
+		"relatedUrl": "https://www.youtube.com/watch?v=qvrdCpLPbuQ",
+		"tier": "Well known names"
 	},
 	{
 		"id": "artificial-analysis",
@@ -109,7 +132,17 @@
 		"logo": "/portfolio/artificial-analysis.ico",
 		"logoSource": "https://artificialanalysis.ai/favicon.ico",
 		"valuation": null,
-		"note": "“Gartner of AI”"
+		"note": "“Gartner of AI”",
+		"tier": "Well known names",
+		"funding": {
+			"amountUsd": null,
+			"date": "2026-01-08",
+			"stage": "Seed · amount undisclosed",
+			"kind": "round",
+			"dateLabel": "Reported Jan 2026",
+			"sourceUrl": "https://www.latent.space/p/artificialanalysis",
+			"sourceTitle": "Latent Space: Artificial Analysis"
+		}
 	},
 	{
 		"id": "browserbase",
@@ -127,7 +160,8 @@
 			"sourceTitle": "Browserbase raises $40M at a $300M valuation",
 			"qualifier": "Series B"
 		},
-		"relatedUrl": "https://www.latent.space/p/browserbase"
+		"relatedUrl": "https://www.latent.space/p/browserbase",
+		"tier": "Well known names"
 	},
 	{
 		"id": "fireworks",
@@ -144,7 +178,8 @@
 			"sourceUrl": "https://fireworks.ai/blog/series-d-announcement",
 			"sourceTitle": "Fireworks announces Series D",
 			"qualifier": "Reported valuation"
-		}
+		},
+		"tier": "Well known names"
 	},
 	{
 		"id": "e2b",
@@ -155,7 +190,24 @@
 		"status": "current",
 		"logo": "/portfolio/e2b.png",
 		"logoSource": "https://cdn.prod.website-files.com/6717bb6618f6a40d53ac2929/6a2a7d8468a4388e03a622aa_Favicon_512x512.png",
-		"valuation": null
+		"valuation": {
+			"amountUsd": 106000000,
+			"date": "2025-07-28",
+			"stage": "Series A",
+			"kind": "reported",
+			"qualifier": "Reported by PostRound",
+			"sourceUrl": "https://postround.substack.com/p/series-a-activity-week-of-july-28",
+			"sourceTitle": "Aaron Harris: Series A activity, week of July 28, 2025"
+		},
+		"tier": "Well known names",
+		"funding": {
+			"amountUsd": 21000000,
+			"date": "2025-07-28",
+			"stage": "Series A",
+			"kind": "round",
+			"sourceUrl": "https://changelog.e2b.dev/blog/series-a",
+			"sourceTitle": "E2B: We raised $21M to give Fortune 100 cloud for AI agents"
+		}
 	},
 	{
 		"id": "daytona",
@@ -173,7 +225,8 @@
 			"sourceTitle": "Datadog and Figma back Daytona",
 			"qualifier": "Post-money · newer mark undisclosed"
 		},
-		"note": "Sandboxes for agents… I know, I know."
+		"note": "Sandboxes for agents… I know, I know.",
+		"tier": "Well known names"
 	},
 	{
 		"id": "resend",
@@ -184,7 +237,24 @@
 		"status": "current",
 		"logo": "/portfolio/resend.png",
 		"logoSource": "https://resend.com/static/favicons/favicon-marketing@57x57.png?v=1",
-		"valuation": null
+		"valuation": {
+			"amountUsd": 25000000,
+			"date": "2023-04-20",
+			"stage": "Angel",
+			"kind": "database-reported",
+			"qualifier": "Angel · database-reported",
+			"sourceUrl": "https://www.cbinsights.com/company/resend/financials",
+			"sourceTitle": "CB Insights: Resend financials"
+		},
+		"tier": "Well known names",
+		"funding": {
+			"amountUsd": 18000000,
+			"date": "2024-12-04",
+			"stage": "Series A",
+			"kind": "round",
+			"sourceUrl": "https://resend.com/blog/series-a",
+			"sourceTitle": "Resend raises $18M Series A"
+		}
 	},
 	{
 		"id": "modal",
@@ -201,7 +271,8 @@
 			"sourceUrl": "https://modal.com/blog/modal-series-c",
 			"sourceTitle": "Modal's $355M Series C at a $4.65B valuation",
 			"qualifier": "Post-money"
-		}
+		},
+		"tier": "Well known names"
 	},
 	{
 		"id": "conductor",
@@ -213,7 +284,16 @@
 		"logo": "/portfolio/conductor.png",
 		"logoSource": "https://www.conductor.build/apple-icon.png?apple-icon.7d575655.png",
 		"valuation": null,
-		"relatedUrl": "https://x.com/charlieholtz/status/2039027121901957349"
+		"relatedUrl": "https://x.com/charlieholtz/status/2039027121901957349",
+		"tier": "Well known names",
+		"funding": {
+			"amountUsd": 22000000,
+			"date": "2026-03-30",
+			"stage": "Series A",
+			"kind": "round",
+			"sourceUrl": "https://www.conductor.build/blog/series-a",
+			"sourceTitle": "Conductor’s Series A"
+		}
 	},
 	{
 		"id": "chroma",
@@ -224,8 +304,16 @@
 		"status": "current",
 		"logo": "/portfolio/chroma.png",
 		"logoSource": "https://www.trychroma.com/img/favicon.ico",
-		"valuation": null,
-		"relatedUrl": "https://www.latent.space/p/chroma"
+		"valuation": {
+			"amountUsd": 75000000,
+			"date": "2023-04-06",
+			"sourceUrl": "https://www.cbinsights.com/company/chroma-6/financials",
+			"sourceTitle": "CB Insights: Chroma April 2023 valuation",
+			"qualifier": "Seed · database-reported",
+			"kind": "reported"
+		},
+		"relatedUrl": "https://www.latent.space/p/chroma",
+		"tier": "Well known names"
 	},
 	{
 		"id": "restate",
@@ -236,7 +324,16 @@
 		"status": "current",
 		"logo": "/portfolio/restate.ico",
 		"logoSource": "https://restate.dev/favicon.ico",
-		"valuation": null
+		"valuation": null,
+		"tier": "Well known names",
+		"funding": {
+			"amountUsd": 7000000,
+			"date": "2024-06-10",
+			"stage": "Seed",
+			"kind": "round",
+			"sourceUrl": "https://restate.dev/blog/announcing-restate-1.0-restate-cloud-and-our-seed-funding-round",
+			"sourceTitle": "Announcing Restate 1.0, Restate Cloud, and our seed funding round"
+		}
 	},
 	{
 		"id": "logan-kilpatrick",
@@ -247,7 +344,8 @@
 		"status": "individual",
 		"logo": null,
 		"logoSource": null,
-		"valuation": null
+		"valuation": null,
+		"tier": "Well known names"
 	},
 	{
 		"id": "matthew-berman",
@@ -258,7 +356,8 @@
 		"status": "individual",
 		"logo": null,
 		"logoSource": null,
-		"valuation": null
+		"valuation": null,
+		"tier": "Well known names"
 	},
 	{
 		"id": "datalab",
@@ -269,7 +368,16 @@
 		"status": "current",
 		"logo": "/portfolio/datalab.svg",
 		"logoSource": "https://www.datalab.to/images/datalab-icon.svg",
-		"valuation": null
+		"valuation": null,
+		"tier": "You should know",
+		"funding": {
+			"amountUsd": 3500000,
+			"date": "2025-06-17",
+			"stage": "Seed",
+			"kind": "round",
+			"sourceUrl": "https://www.forkable.io/p/datalab-develops-small-ai-models",
+			"sourceTitle": "Paul Sawers: Datalab develops small AI models to power document intelligence in the enterprise"
+		}
 	},
 	{
 		"id": "viktor",
@@ -287,7 +395,8 @@
 			"sourceTitle": "Forbes Polska profile of Viktor",
 			"qualifier": "Reported valuation",
 			"dateLabel": "May 2026 · reported Jul 2026"
-		}
+		},
+		"tier": "You should know"
 	},
 	{
 		"id": "brightwave",
@@ -298,7 +407,16 @@
 		"status": "current",
 		"logo": "/portfolio/brightwave.svg",
 		"logoSource": "https://www.brightwave.io/favicon.svg",
-		"valuation": null
+		"valuation": null,
+		"tier": "You should know",
+		"funding": {
+			"amountUsd": 15000000,
+			"date": "2024-10-29",
+			"stage": "Series A",
+			"kind": "round",
+			"sourceUrl": "https://markets.financialcontent.com/stocks/article/bizwire-2024-10-29-brightwave-secures-15m-series-a-to-scale-ai-powered-financial-research-platform",
+			"sourceTitle": "Brightwave secures $15M Series A to scale AI-powered financial research platform"
+		}
 	},
 	{
 		"id": "quadratic",
@@ -309,7 +427,16 @@
 		"status": "current",
 		"logo": "/portfolio/quadratic.png",
 		"logoSource": "https://www.quadratichq.com/apple-icon.png?3f818aa4b7854e48",
-		"valuation": null
+		"valuation": null,
+		"tier": "You should know",
+		"funding": {
+			"amountUsd": 5600000,
+			"date": "2024-04-02",
+			"stage": "Seed",
+			"kind": "round",
+			"sourceUrl": "https://www.quadratichq.com/blog/announcing-our-seed-round-funding-and-quadratic-teams",
+			"sourceTitle": "Announcing our $5.6M seed round and Quadratic Teams"
+		}
 	},
 	{
 		"id": "flutterflow",
@@ -327,7 +454,8 @@
 			"sourceTitle": "FlutterFlow raises Series A",
 			"qualifier": "Reported valuation",
 			"prefix": "≈"
-		}
+		},
+		"tier": "You should know"
 	},
 	{
 		"id": "circle",
@@ -345,7 +473,8 @@
 			"sourceTitle": "The Split: Circle CEO Sid Yadav interview",
 			"qualifier": "Reported valuation",
 			"dateLabel": "2023 · reported Jan 2024"
-		}
+		},
+		"tier": "You should know"
 	},
 	{
 		"id": "airbyte",
@@ -362,7 +491,8 @@
 			"sourceUrl": "https://airbyte.com/blog/a-150m-series-b-to-power-the-movement-of-data",
 			"sourceTitle": "Airbyte raises $150M Series B",
 			"qualifier": "Reported valuation"
-		}
+		},
+		"tier": "You should know"
 	},
 	{
 		"id": "sphere",
@@ -373,7 +503,16 @@
 		"status": "current",
 		"logo": null,
 		"logoSource": null,
-		"valuation": null
+		"valuation": null,
+		"tier": "You should know",
+		"funding": {
+			"amountUsd": 12500000,
+			"date": "2025-09-22",
+			"stage": "Financing",
+			"kind": "round",
+			"sourceUrl": "https://www.constructcap.com/articles/investing-in-sphere-semi-reinventing-analog-chip-design-for-the-ai-era",
+			"sourceTitle": "Investing in Sphere Semi: Reinventing Analog Chip Design for the AI Era"
+		}
 	},
 	{
 		"id": "val-town",
@@ -384,7 +523,16 @@
 		"status": "current",
 		"logo": "/portfolio/val-town.svg",
 		"logoSource": "https://www.val.town/favicon.svg?dot=false",
-		"valuation": null
+		"valuation": null,
+		"tier": "You should know",
+		"funding": {
+			"amountUsd": 5500000,
+			"date": "2024-04-09",
+			"stage": "Seed",
+			"kind": "round",
+			"sourceUrl": "https://blog.val.town/blog/seed/",
+			"sourceTitle": "Val Town’s seed round"
+		}
 	},
 	{
 		"id": "stackblitz",
@@ -401,7 +549,8 @@
 			"sourceUrl": "https://research.contrary.com/company/bolt",
 			"sourceTitle": "Contrary Research: Bolt business breakdown",
 			"qualifier": "Post-money; January 2025 Series B"
-		}
+		},
+		"tier": "You should know"
 	},
 	{
 		"id": "preference-model",
@@ -412,7 +561,8 @@
 		"status": "current",
 		"logo": "/portfolio/preference-model.ico",
 		"logoSource": "https://preferencemodel.com/favicon.ico?favicon.1d4fa6c9.ico",
-		"valuation": null
+		"valuation": null,
+		"tier": "Smaller names"
 	},
 	{
 		"id": "littlebird",
@@ -423,7 +573,16 @@
 		"status": "current",
 		"logo": "/portfolio/littlebird.png",
 		"logoSource": "https://cdn.prod.website-files.com/694043d273dceabab479f631/6a55a1a906eabfade48dce1e_69603245cff328dc64a18f61_Base%20Icon%20%5BDO%20NOT%20EDIT%5D%206.png",
-		"valuation": null
+		"valuation": null,
+		"tier": "Smaller names",
+		"funding": {
+			"amountUsd": 11000000,
+			"date": "2026-03-22",
+			"stage": "Seed",
+			"kind": "round",
+			"sourceUrl": "https://littlebird.ai/blog/littlebird-raises-11m-to-build-the-first-full-context-ai",
+			"sourceTitle": "Littlebird raises $11M to build the first full-context AI"
+		}
 	},
 	{
 		"id": "clarify",
@@ -434,7 +593,16 @@
 		"status": "current",
 		"logo": "/portfolio/clarify.png",
 		"logoSource": "https://www.clarify.ai/_next/static/media/favicon.0mmn2nasvvrs8.png",
-		"valuation": null
+		"valuation": null,
+		"tier": "Smaller names",
+		"funding": {
+			"amountUsd": 15000000,
+			"date": "2025-06-25",
+			"stage": "Series A · newer round undisclosed",
+			"kind": "round",
+			"sourceUrl": "https://www.cbinsights.com/company/clarify-4/financials",
+			"sourceTitle": "CB Insights: Clarify financials"
+		}
 	},
 	{
 		"id": "phonic",
@@ -445,7 +613,16 @@
 		"status": "current",
 		"logo": "/portfolio/phonic.svg",
 		"logoSource": "https://phonic.ai/icon.svg?icon.0rsnuu632fkn7.svg",
-		"valuation": null
+		"valuation": null,
+		"tier": "Smaller names",
+		"funding": {
+			"amountUsd": 4000000,
+			"date": "2025-04-03",
+			"stage": "Seed",
+			"kind": "round",
+			"sourceUrl": "https://www.prnewswire.com/news-releases/phonic-launches-end-to-end-speech-to-speech-platform-for-building-reliable-voice-agents-announces-4m-funding-raise-302419143.html",
+			"sourceTitle": "Phonic launches speech-to-speech platform and announces $4M funding"
+		}
 	},
 	{
 		"id": "keycard",
@@ -456,7 +633,16 @@
 		"status": "current",
 		"logo": "/portfolio/keycard.svg",
 		"logoSource": "https://www.keycard.ai/favicon.svg",
-		"valuation": null
+		"valuation": null,
+		"tier": "Smaller names",
+		"funding": {
+			"amountUsd": 30000000,
+			"date": "2025-10-21",
+			"stage": "Series A",
+			"kind": "round",
+			"sourceUrl": "https://boldstart.vc/news/keycard-solving-the-ai-agent-identity-and-access-problem-welcome-to-boldstart/",
+			"sourceTitle": "Keycard: Solving the AI agent identity and access problem"
+		}
 	},
 	{
 		"id": "confident-security",
@@ -467,7 +653,16 @@
 		"status": "current",
 		"logo": "/portfolio/confident-security.svg",
 		"logoSource": "https://confident.security/favicon.svg",
-		"valuation": null
+		"valuation": null,
+		"tier": "Smaller names",
+		"funding": {
+			"amountUsd": 4200000,
+			"date": "2025-07-17",
+			"stage": "Seed",
+			"kind": "round",
+			"sourceUrl": "https://techcrunch.com/2025/07/17/confident-security-the-signal-for-ai-comes-out-of-stealth-with-4-2m/",
+			"sourceTitle": "Confident Security, the Signal for AI, comes out of stealth with $4.2M"
+		}
 	},
 	{
 		"id": "lightweight-labs",
@@ -478,7 +673,8 @@
 		"status": "current",
 		"logo": "/portfolio/lightweight-labs.png",
 		"logoSource": "https://instabooks.io/img/apple-touch-icon.png",
-		"valuation": null
+		"valuation": null,
+		"tier": "Smaller names"
 	},
 	{
 		"id": "wordware",
@@ -489,7 +685,16 @@
 		"status": "current",
 		"logo": "/portfolio/wordware.png",
 		"logoSource": "https://www.wordware.ai/Wordware%20Favicon.png",
-		"valuation": null
+		"valuation": null,
+		"tier": "Smaller names",
+		"funding": {
+			"amountUsd": 30000000,
+			"date": "2024-11-25",
+			"stage": "Seed",
+			"kind": "round",
+			"sourceUrl": "https://blog.wordware.ai/seed-round",
+			"sourceTitle": "Wordware raises $30M seed round"
+		}
 	},
 	{
 		"id": "polyhive",
@@ -500,7 +705,8 @@
 		"status": "current",
 		"logo": null,
 		"logoSource": null,
-		"valuation": null
+		"valuation": null,
+		"tier": "Smaller names"
 	},
 	{
 		"id": "sailplane",
@@ -511,7 +717,8 @@
 		"status": "current",
 		"logo": "/portfolio/sailplane.png",
 		"logoSource": "https://www.sailplane.ai/apple-icon.png?2aa3577447c0af88",
-		"valuation": null
+		"valuation": null,
+		"tier": "Smaller names"
 	},
 	{
 		"id": "morph",
@@ -522,7 +729,8 @@
 		"status": "current",
 		"logo": "/portfolio/morph.png",
 		"logoSource": "https://www.morph.so/logo.png",
-		"valuation": null
+		"valuation": null,
+		"tier": "Smaller names"
 	},
 	{
 		"id": "fireproof",
@@ -533,7 +741,16 @@
 		"status": "current",
 		"logo": "/portfolio/fireproof.ico",
 		"logoSource": "https://fireproof.storage/favicon.ico",
-		"valuation": null
+		"valuation": null,
+		"tier": "Smaller names",
+		"funding": {
+			"amountUsd": 1710000,
+			"date": "2024-07-31",
+			"stage": "Pre-seed",
+			"kind": "round",
+			"sourceUrl": "https://www.cbinsights.com/company/fireproof-storage",
+			"sourceTitle": "Fireproof Storage — CBInsights"
+		}
 	},
 	{
 		"id": "arcjet",
@@ -544,7 +761,16 @@
 		"status": "current",
 		"logo": "/portfolio/arcjet.png",
 		"logoSource": "https://arcjet.com/favicon.png",
-		"valuation": null
+		"valuation": null,
+		"tier": "Smaller names",
+		"funding": {
+			"amountUsd": 8300000,
+			"date": "2025-10-08",
+			"stage": "Series A",
+			"kind": "round",
+			"sourceUrl": "https://blog.arcjet.com/introducing-arcjets-local-ai-security-model-announcing-series-a-funding/",
+			"sourceTitle": "Introducing Arcjet's local AI security model + announcing Series A funding"
+		}
 	},
 	{
 		"id": "cosine",
@@ -555,7 +781,24 @@
 		"status": "current",
 		"logo": "/portfolio/cosine.png",
 		"logoSource": "https://cosine.sh/manifest/apple-touch-icon-57x57.png",
-		"valuation": null
+		"valuation": {
+			"amountUsd": 15000000,
+			"date": "2023-04",
+			"dateLabel": "Apr 2023",
+			"kind": "database-reported",
+			"qualifier": "Seed · database-reported",
+			"sourceUrl": "https://www.cbinsights.com/company/buildt/financials",
+			"sourceTitle": "Cosine Stock Price, Funding, Valuation — CBInsights"
+		},
+		"tier": "Smaller names",
+		"funding": {
+			"amountUsd": 8000000,
+			"date": "2026-06-08",
+			"stage": "Total funding disclosed",
+			"kind": "total",
+			"sourceUrl": "https://pathfounders.com/p/cosine-ai-recruits-corporate-heavyweights-to-build-sovereign",
+			"sourceTitle": "Cosine AI recruits corporate heavyweights to build sovereign UK frontier AI model"
+		}
 	},
 	{
 		"id": "responsive",
@@ -566,7 +809,8 @@
 		"status": "current",
 		"logo": "/portfolio/responsive.svg",
 		"logoSource": "https://www.responsive.dev/favicon.svg",
-		"valuation": null
+		"valuation": null,
+		"tier": "Smaller names"
 	},
 	{
 		"id": "budibase",
@@ -577,7 +821,16 @@
 		"status": "current",
 		"logo": "/portfolio/budibase.png",
 		"logoSource": "https://budibase.com/apple-touch-icon.png",
-		"valuation": null
+		"valuation": null,
+		"tier": "Smaller names",
+		"funding": {
+			"amountUsd": 7000000,
+			"date": "2022-11-04",
+			"stage": "Seed II",
+			"kind": "round",
+			"sourceUrl": "https://budibase.com/blog/updates/budibase-raises-7m-to-help-every-company-on-the-planet-build-their-own-tools/",
+			"sourceTitle": "Budibase raises $7M to help every company build their own tools"
+		}
 	},
 	{
 		"id": "100ms",
@@ -588,7 +841,16 @@
 		"status": "current",
 		"logo": "/portfolio/100ms.png",
 		"logoSource": "https://www.100ms.live/favicons/apple-touch-icon.png",
-		"valuation": null
+		"valuation": null,
+		"tier": "Smaller names",
+		"funding": {
+			"amountUsd": 20000000,
+			"date": "2022-03-10",
+			"stage": "Series A",
+			"kind": "round",
+			"sourceUrl": "https://techcrunch.com/2022/03/10/100ms-secures-20m-to-power-next-generation-of-live-video-apps/",
+			"sourceTitle": "100ms secures $20M to power live video apps"
+		}
 	},
 	{
 		"id": "expand",
@@ -599,7 +861,8 @@
 		"status": "current",
 		"logo": "/portfolio/expand.ico",
 		"logoSource": "https://expand.ai/favicon.ico",
-		"valuation": null
+		"valuation": null,
+		"tier": "Smaller names"
 	},
 	{
 		"id": "catamaran",
@@ -610,7 +873,8 @@
 		"status": "current",
 		"logo": null,
 		"logoSource": null,
-		"valuation": null
+		"valuation": null,
+		"tier": "Smaller names"
 	},
 	{
 		"id": "replay",
@@ -622,7 +886,16 @@
 		"logo": "/portfolio/replay.ico",
 		"logoSource": "https://www.replay.io/favicon.ico",
 		"valuation": null,
-		"note": "Still alive!"
+		"note": "Still alive!",
+		"tier": "Smaller names",
+		"funding": {
+			"amountUsd": 13000000,
+			"date": "2023-06-13",
+			"stage": "Series A",
+			"kind": "round",
+			"sourceUrl": "https://www.replay.io/blog/replay-for-test-suites",
+			"sourceTitle": "Replay for Test Suites: $13M Series A announcement"
+		}
 	},
 	{
 		"id": "astral",
@@ -634,7 +907,16 @@
 		"logo": "/portfolio/astral.png",
 		"logoSource": "https://astral.sh/static/apple-touch-icon.png",
 		"valuation": null,
-		"acquirer": "OpenAI"
+		"acquirer": "OpenAI",
+		"tier": "Done",
+		"funding": {
+			"amountUsd": 4000000,
+			"date": "2023-04-18",
+			"stage": "Seed; later rounds undisclosed",
+			"kind": "round",
+			"sourceUrl": "https://astral.sh/blog/announcing-astral-the-company-behind-ruff",
+			"sourceTitle": "Announcing Astral, the company behind Ruff"
+		}
 	},
 	{
 		"id": "promptfoo",
@@ -653,7 +935,8 @@
 			"qualifier": "Post-money · before exit",
 			"prefix": "≈"
 		},
-		"acquirer": "OpenAI"
+		"acquirer": "OpenAI",
+		"tier": "Done"
 	},
 	{
 		"id": "gabber",
@@ -665,7 +948,8 @@
 		"logo": "/portfolio/gabber.png",
 		"logoSource": "https://gabber.dev/favicon.ico",
 		"valuation": null,
-		"acquirer": "LiveKit"
+		"acquirer": "LiveKit",
+		"tier": "Done"
 	},
 	{
 		"id": "codegen",
@@ -683,7 +967,8 @@
 			"sourceTitle": "Codegen raises new cash to automate software engineering tasks",
 			"qualifier": "Post-money · before exit"
 		},
-		"acquirer": "ClickUp"
+		"acquirer": "ClickUp",
+		"tier": "Done"
 	},
 	{
 		"id": "brev",
@@ -694,8 +979,17 @@
 		"status": "exited",
 		"logo": "/portfolio/brev.ico",
 		"logoSource": "https://brev.nvidia.com/favicon.ico",
-		"valuation": null,
-		"acquirer": "NVIDIA"
+		"valuation": {
+			"amountUsd": 8500000,
+			"maxAmountUsd": 10000000,
+			"date": "2021-08-24",
+			"kind": "database-reported",
+			"qualifier": "Database range · before exit",
+			"sourceUrl": "https://www.cbinsights.com/company/brevdev/financials",
+			"sourceTitle": "Brev Stock Price, Funding, Valuation — CBInsights"
+		},
+		"acquirer": "NVIDIA",
+		"tier": "Done"
 	},
 	{
 		"id": "gel",
@@ -707,7 +1001,16 @@
 		"logo": "/portfolio/gel.png",
 		"logoSource": "https://www.geldata.com/apple-touch-icon.png",
 		"valuation": null,
-		"acquirer": "Vercel"
+		"acquirer": "Vercel",
+		"tier": "Done",
+		"funding": {
+			"amountUsd": 15000000,
+			"date": "2022-11-07",
+			"stage": "Series A",
+			"kind": "round",
+			"sourceUrl": "https://www.prnewswire.com/news-releases/edgedb-raises-15m-series-a-round-to-bring-its-modernized-relational-database-for-cutting-edge-apps-to-the-cloud-301669752.html",
+			"sourceTitle": "EdgeDB Raises $15M Series A Round"
+		}
 	},
 	{
 		"id": "dynamic",
@@ -718,8 +1021,17 @@
 		"status": "exited",
 		"logo": "/portfolio/dynamic.jpg",
 		"logoSource": "https://cdn.prod.website-files.com/626692727bba3f384e008e8a/6939931f0bc7313794dc74c8_Webclip.jpg",
-		"valuation": null,
-		"acquirer": "Fireblocks"
+		"valuation": {
+			"amountUsd": 64300000,
+			"dateLabel": "Q4 2023 · reported Mar 2024",
+			"kind": "database-reported",
+			"qualifier": "Post-money · PitchBook",
+			"sourceUrl": "https://files.pitchbook.com/website/files/pdf/Q4_2023_Emerging_Tech_Indicator.pdf#page=22",
+			"sourceTitle": "PitchBook Q4 2023 Emerging Tech Indicator, page22",
+			"date": "2024-03-13"
+		},
+		"acquirer": "Fireblocks",
+		"tier": "Done"
 	},
 	{
 		"id": "begin",
@@ -731,7 +1043,8 @@
 		"logo": null,
 		"logoSource": null,
 		"valuation": null,
-		"relatedUrl": "https://www.sanity.io/blog/welcoming-the-begin-team-to-sanity"
+		"relatedUrl": "https://www.sanity.io/blog/welcoming-the-begin-team-to-sanity",
+		"tier": "Done"
 	},
 	{
 		"id": "dimension",
@@ -742,6 +1055,16 @@
 		"status": "closed",
 		"logo": null,
 		"logoSource": null,
-		"valuation": null
+		"valuation": null,
+		"tier": "Done",
+		"funding": {
+			"amountUsd": 350000,
+			"dateLabel": "Jan 2025 profile",
+			"date": "2025-01-01",
+			"stage": "Total disclosed funding",
+			"kind": "total",
+			"sourceUrl": "https://techcrunch.com/startup-battlefield/company/dimension/",
+			"sourceTitle": "Dimension — TechCrunch Startup Battlefield"
+		}
 	}
 ]

--- a/src/lib/portfolio.js
+++ b/src/lib/portfolio.js
@@ -1,25 +1,36 @@
 /**
  * Public company marks, not the value of my holdings. A null valuation means
  * no public figure was verified; it must never be treated as zero.
- * @typedef {{ amountUsd: number, date: string, sourceUrl: string, sourceTitle: string, qualifier?: string, prefix?: string, dateLabel?: string }} Valuation
- * @typedef {{ id: string, name: string, website: string | null, description: string, category: string, status: string, logo: string | null, logoSource: string | null, valuation: Valuation | null, relatedUrl?: string, note?: string, acquirer?: string }} PortfolioCompany
+ * @typedef {{ amountUsd: number, maxAmountUsd?: number, date: string, sourceUrl: string, sourceTitle: string, qualifier?: string, prefix?: string, dateLabel?: string, kind?: 'reported' | 'database-reported' | 'filing-derived' }} Valuation
+ * @typedef {{ amountUsd: number | null, date: string, dateLabel?: string, stage: string, kind?: 'round' | 'total', sourceUrl: string, sourceTitle: string }} FundingRound
+ * @typedef {{ id: string, name: string, website: string | null, description: string, category: string, tier: string, status: string, logo: string | null, logoSource: string | null, valuation: Valuation | null, funding?: FundingRound, relatedUrl?: string, note?: string, acquirer?: string }} PortfolioCompany
  */
+
+// These are the original editorial groups, not financial rankings or funding stages.
+export const PORTFOLIO_TIERS = ['Well known names', 'You should know', 'Smaller names', 'Done'];
 
 /**
  * @param {PortfolioCompany[]} companies
- * @param {{ query?: string, category?: string, status?: string, sort?: string }} filters
+ * @param {{ query?: string, category?: string, tier?: string, status?: string, sort?: string }} filters
  */
 export function filterPortfolio(
 	companies,
-	{ query = '', category = '', status = '', sort = '' } = {}
+	{ query = '', category = '', tier = '', status = '', sort = '' } = {}
 ) {
 	const words = query.trim().toLocaleLowerCase('en-US').split(/\s+/).filter(Boolean);
 	const result = companies.filter((company) => {
-		const haystack = [company.name, company.description, company.category, company.acquirer ?? '']
+		const haystack = [
+			company.name,
+			company.description,
+			company.category,
+			company.tier,
+			company.acquirer ?? ''
+		]
 			.join(' ')
 			.toLocaleLowerCase('en-US');
 		return (
 			(!category || company.category === category) &&
+			(!tier || company.tier === tier) &&
 			(!status || company.status === status) &&
 			words.every((word) => haystack.includes(word))
 		);
@@ -32,15 +43,23 @@ export function filterPortfolio(
 
 /** @param {number} amountUsd */
 export function formatValuation(amountUsd) {
-	const unit = amountUsd >= 1_000_000_000 ? 1_000_000_000 : 1_000_000;
-	return `$${new Intl.NumberFormat('en-US', { maximumFractionDigits: 2 }).format(amountUsd / unit)}${unit === 1_000_000_000 ? 'B' : 'M'}`;
+	const unit =
+		amountUsd >= 1_000_000_000 ? 1_000_000_000 : amountUsd >= 1_000_000 ? 1_000_000 : 1_000;
+	return `$${new Intl.NumberFormat('en-US', { maximumFractionDigits: 2 }).format(amountUsd / unit)}${unit === 1_000_000_000 ? 'B' : unit === 1_000_000 ? 'M' : 'K'}`;
+}
+
+/** @param {Valuation} valuation */
+export function formatPortfolioValuation(valuation) {
+	const amount = formatValuation(valuation.amountUsd);
+	return `${valuation.prefix ?? ''}${amount}${valuation.maxAmountUsd ? `–${formatValuation(valuation.maxAmountUsd)}` : ''}`;
 }
 
 /** @param {string} date */
 export function formatValuationDate(date) {
+	const normalized = date.length === 7 ? `${date}-01` : date;
 	return new Intl.DateTimeFormat('en-US', {
 		month: 'short',
 		year: 'numeric',
 		timeZone: 'UTC'
-	}).format(new Date(`${date}T00:00:00Z`));
+	}).format(new Date(`${normalized}T00:00:00Z`));
 }

--- a/src/routes/portfolio/+page.svelte
+++ b/src/routes/portfolio/+page.svelte
@@ -1,21 +1,29 @@
 <script>
 	import SocialMeta from '../../components/SocialMeta.svelte';
 	import { getPageSocialMeta } from '$lib/social-meta';
-	import { filterPortfolio, formatValuation, formatValuationDate } from '$lib/portfolio';
+	import {
+		PORTFOLIO_TIERS,
+		filterPortfolio,
+		formatValuation,
+		formatPortfolioValuation,
+		formatValuationDate
+	} from '$lib/portfolio';
 
 	/** @type {{ companies: import('$lib/portfolio').PortfolioCompany[], reviewedAt: string }} */
 	export let data;
 	const social = getPageSocialMeta('portfolio');
 	let query = '';
 	let category = '';
+	let tier = '';
 	let status = '';
 	let sort = '';
 	$: categories = [...new Set(data.companies.map((company) => company.category))].sort();
-	$: companies = filterPortfolio(data.companies, { query, category, status, sort });
-	$: hasFilters = Boolean(query || category || status || sort);
+	$: companies = filterPortfolio(data.companies, { query, category, tier, status, sort });
+	$: hasFilters = Boolean(query || category || tier || status || sort);
 	function resetFilters() {
 		query = '';
 		category = '';
+		tier = '';
 		status = '';
 		sort = '';
 	}
@@ -63,6 +71,13 @@
 				</select>
 			</label>
 			<label>
+				<span>Original tier</span>
+				<select bind:value={tier}>
+					<option value="">All tiers</option>
+					{#each PORTFOLIO_TIERS as option}<option value={option}>{option}</option>{/each}
+				</select>
+			</label>
+			<label>
 				<span>Status</span>
 				<select bind:value={status}>
 					<option value="">All entries</option>
@@ -102,6 +117,7 @@
 					<th role="columnheader" scope="col">Company / person</th>
 					<th role="columnheader" scope="col">What they do</th>
 					<th role="columnheader" scope="col">Category</th>
+					<th role="columnheader" scope="col">Status / tier</th>
 					<th role="columnheader" scope="col" class="valuation-column">Last public valuation</th>
 				</tr>
 			</thead>
@@ -137,13 +153,6 @@
 											>{company.name}</a
 										>
 									{:else}<span class="company-name">{company.name}</span>{/if}
-									{#if company.acquirer}<span class="company-status"
-											>Exited → {company.acquirer}</span
-										>
-									{:else if company.status === 'closed'}<span class="company-status">Closed</span>
-									{:else if company.status === 'individual'}<span class="company-status"
-											>Individual backing</span
-										>{/if}
 								</div>
 							</div>
 						</th>
@@ -159,6 +168,14 @@
 						<td role="cell" class="category-cell"
 							><span class="category-label">{company.category}</span></td
 						>
+						<td role="cell" class="tier-cell">
+							<span class="tier-label">{company.tier}</span>
+							{#if company.acquirer}<span class="company-status">Exited → {company.acquirer}</span>
+							{:else if company.status === 'closed'}<span class="company-status">Closed</span>
+							{:else if company.status === 'individual'}<span class="company-status"
+									>Individual backing</span
+								>{/if}
+						</td>
 						<td role="cell" class="valuation-cell">
 							<span class="mobile-label" aria-hidden="true">Last public valuation</span>
 							{#if company.valuation}
@@ -166,9 +183,9 @@
 									class="valuation-value"
 									href={company.valuation.sourceUrl}
 									title={company.valuation.sourceTitle}
-									aria-label={`${company.name}: ${company.valuation.prefix ?? ''}${formatValuation(company.valuation.amountUsd)}. ${company.valuation.sourceTitle}`}
+									aria-label={`${company.name}: ${formatPortfolioValuation(company.valuation)}. ${company.valuation.sourceTitle}`}
 								>
-									{company.valuation.prefix ?? ''}{formatValuation(company.valuation.amountUsd)}
+									{formatPortfolioValuation(company.valuation)}
 									<span aria-hidden="true">↗</span>
 								</a>
 								<time datetime={company.valuation.date}
@@ -178,8 +195,29 @@
 								{#if company.valuation.qualifier}<small>{company.valuation.qualifier}</small>{/if}
 							{:else}
 								<span class="unavailable"
-									>{company.status === 'individual' ? 'Not applicable' : 'Not available'}</span
+									>{company.status === 'individual'
+										? 'Not applicable'
+										: 'No public figure found'}</span
 								>
+								{#if company.funding}
+									<a
+										class="funding-link"
+										href={company.funding.sourceUrl}
+										title={company.funding.sourceTitle}
+									>
+										{#if company.funding.amountUsd !== null}
+											{formatValuation(company.funding.amountUsd)}
+											{company.funding.kind === 'total' ? 'total raised' : 'raised'} ↗
+										{:else}Funding announced ↗{/if}
+									</a>
+									<small
+										>{company.funding.stage} ·
+										<time datetime={company.funding.date}
+											>{company.funding.dateLabel ??
+												formatValuationDate(company.funding.date)}</time
+										></small
+									>
+								{/if}
 							{/if}
 						</td>
 					</tr>
@@ -197,10 +235,12 @@
 			</div>
 		{/if}
 		<p id="valuation-note" class="valuation-note">
-			Valuations are the latest public figures I could verify, in USD, with dates and sources—not
-			the value of my holdings or the amount raised. “Not available” means no public valuation was
-			verified. Figures may be out of date; acquisition prices are not treated as funding
-			valuations. Initials stand in where a public logo isn’t available.
+			Valuations are dated public company marks in USD, not the value of my holdings. Filing-derived
+			estimates are labeled; older rounds stay dated and may not reflect today’s value. Where no
+			valuation was found, a linked funding round is shown when available—“raised” is funding, not
+			valuation. Acquisition prices are not treated as funding valuations. Tiers preserve my
+			original groups, not a financial ranking. Initials stand in where a public logo isn’t
+			available.
 		</p>
 	</section>
 
@@ -229,6 +269,7 @@
 
 <style>
 	.portfolio-page {
+		--site-max-width: 1160px;
 		margin-block: 2.5rem 4rem;
 	}
 	.portfolio-intro {
@@ -277,7 +318,7 @@
 	}
 	.portfolio-controls {
 		display: grid;
-		grid-template-columns: minmax(200px, 1fr) 180px 140px 175px;
+		grid-template-columns: minmax(200px, 1fr) 170px 175px 130px 175px;
 		gap: 0.75rem;
 	}
 	.portfolio-controls label {
@@ -350,16 +391,19 @@
 		border-block: 1px solid var(--page-border);
 	}
 	thead th:nth-child(1) {
-		width: 24%;
+		width: 22%;
 	}
 	thead th:nth-child(2) {
-		width: 37%;
+		width: 30%;
 	}
 	thead th:nth-child(3) {
-		width: 20%;
+		width: 15%;
 	}
 	thead th:nth-child(4) {
-		width: 19%;
+		width: 16%;
+	}
+	thead th:nth-child(5) {
+		width: 17%;
 	}
 	tbody tr {
 		border-bottom: 1px solid var(--page-border);
@@ -419,6 +463,20 @@
 		font-size: 0.7rem;
 		line-height: 1.4;
 		margin-top: 0.25rem;
+	}
+	.tier-label {
+		display: inline-block;
+		color: var(--page-gold);
+		font-size: 0.75rem;
+		font-weight: 600;
+	}
+	.funding-link {
+		display: block;
+		margin-top: 0.35rem;
+		font-size: 0.75rem;
+	}
+	.valuation-cell small time {
+		display: inline;
 	}
 	.description-cell {
 		line-height: 1.6;
@@ -509,9 +567,12 @@
 		font-size: 0.85rem;
 		line-height: 1.7;
 	}
-	@media (max-width: 850px) {
+	@media (max-width: 980px) {
 		.portfolio-controls {
 			grid-template-columns: 1fr 1fr;
+		}
+		.search-field {
+			grid-column: 1 / -1;
 		}
 		.portfolio-notes {
 			gap: 1.5rem;
@@ -535,9 +596,6 @@
 			font-size: 1rem;
 		}
 		.search-field {
-			grid-column: 1 / -1;
-		}
-		.portfolio-controls label:last-child {
 			grid-column: 1 / -1;
 		}
 		.review-date {
@@ -581,7 +639,16 @@
 			margin-block: 0.8rem;
 		}
 		.category-cell {
+			grid-area: 3 / 1;
 			padding-top: 0.15rem;
+		}
+		.tier-cell {
+			grid-area: 4 / 1;
+			padding-top: 0.5rem;
+		}
+		.valuation-cell {
+			grid-area: 3 / 2 / 5 / 3;
+			max-width: 10rem;
 		}
 		.mobile-label {
 			display: block;

--- a/tests/portfolio.test.mjs
+++ b/tests/portfolio.test.mjs
@@ -1,7 +1,13 @@
 import assert from 'node:assert/strict';
 import { readFile, stat } from 'node:fs/promises';
 import test from 'node:test';
-import { filterPortfolio, formatValuation, formatValuationDate } from '../src/lib/portfolio.js';
+import {
+	PORTFOLIO_TIERS,
+	filterPortfolio,
+	formatPortfolioValuation,
+	formatValuation,
+	formatValuationDate
+} from '../src/lib/portfolio.js';
 
 const root = new URL('../', import.meta.url);
 const companies = JSON.parse(await readFile(new URL('src/lib/data/portfolio.json', root), 'utf8'));
@@ -27,14 +33,119 @@ test('every public valuation has a positive amount, dated source, and no future 
 		const valuation = company.valuation;
 		if (valuation === null) continue;
 		assert.ok(Number.isFinite(valuation.amountUsd) && valuation.amountUsd > 0, company.name);
-		assert.match(valuation.date, /^\d{4}-\d{2}-\d{2}$/);
+		assert.match(valuation.date, /^\d{4}-\d{2}(-\d{2})?$/);
 		assert.ok(Date.parse(valuation.date) <= Date.parse('2026-08-26'), company.name);
 		assert.equal(new URL(valuation.sourceUrl).protocol, 'https:');
 		assert.ok(valuation.sourceTitle);
 	}
 	assert.equal(companies.find((company) => company.id === 'matx').valuation.prefix, '>');
 	assert.match(companies.find((company) => company.id === 'circle').valuation.dateLabel, /^2023/);
-	assert.equal(companies.find((company) => company.id === 'railway').valuation, null);
+	for (const company of companies.filter(
+		(company) => company.valuation?.kind === 'filing-derived'
+	)) {
+		assert.equal(company.valuation.prefix, '≈');
+		assert.match(company.valuation.qualifier, /[Ff]iling-derived/);
+	}
+});
+
+test('original tiers retain their exact memberships independently of status', () => {
+	const groups = companies.reduce((groups, company) => {
+		(groups[company.tier] ??= []).push(company.id);
+		return groups;
+	}, {});
+	assert.deepEqual(Object.keys(groups), PORTFOLIO_TIERS);
+	assert.deepEqual(groups, {
+		'Well known names': [
+			'temporal',
+			'cognition',
+			'supabase',
+			'railway',
+			'workos',
+			'matx',
+			'artificial-analysis',
+			'browserbase',
+			'fireworks',
+			'e2b',
+			'daytona',
+			'resend',
+			'modal',
+			'conductor',
+			'chroma',
+			'restate',
+			'logan-kilpatrick',
+			'matthew-berman'
+		],
+		'You should know': [
+			'datalab',
+			'viktor',
+			'brightwave',
+			'quadratic',
+			'flutterflow',
+			'circle',
+			'airbyte',
+			'sphere',
+			'val-town',
+			'stackblitz'
+		],
+		'Smaller names': [
+			'preference-model',
+			'littlebird',
+			'clarify',
+			'phonic',
+			'keycard',
+			'confident-security',
+			'lightweight-labs',
+			'wordware',
+			'polyhive',
+			'sailplane',
+			'morph',
+			'fireproof',
+			'arcjet',
+			'cosine',
+			'responsive',
+			'budibase',
+			'100ms',
+			'expand',
+			'catamaran',
+			'replay'
+		],
+		Done: [
+			'astral',
+			'promptfoo',
+			'gabber',
+			'codegen',
+			'brev',
+			'gel',
+			'dynamic',
+			'begin',
+			'dimension'
+		]
+	});
+	assert.deepEqual(
+		filterPortfolio(companies, { tier: 'Done', status: 'closed' }).map((company) => company.id),
+		['begin', 'dimension']
+	);
+	assert.equal(
+		filterPortfolio(companies, { tier: 'Smaller names', category: 'AI coding' }).length,
+		1
+	);
+	assert.equal(filterPortfolio(companies, { tier: 'You should know', status: 'exited' }).length, 0);
+});
+
+test('funding evidence stays distinct from valuations and has its own dated source', () => {
+	const funded = companies.filter((company) => company.funding);
+	for (const { funding } of funded) {
+		if (funding.amountUsd !== null)
+			assert.ok(funding.amountUsd > 0 && Number.isFinite(funding.amountUsd));
+		assert.ok(funding.stage && funding.sourceTitle);
+		assert.equal(new URL(funding.sourceUrl).protocol, 'https:');
+		assert.ok(Date.parse(funding.date) <= Date.parse('2026-08-26'));
+	}
+	const fixture = [
+		{ ...companies[0], id: 'funding-only', valuation: null, funding: { amountUsd: 1e12 } },
+		{ ...companies[1], id: 'valued', valuation: { amountUsd: 1e6 } }
+	];
+	assert.equal(filterPortfolio(fixture, { sort: 'valuation' })[0].id, 'valued');
 });
 
 test('logos are local, nonempty assets with recorded provenance', async () => {
@@ -81,4 +192,11 @@ test('valuation formatting preserves meaningful precision and stable UTC dates',
 	assert.equal(formatValuation(10_500_000_000), '$10.5B');
 	assert.equal(formatValuation(125_000_000), '$125M');
 	assert.equal(formatValuationDate('2026-06-01'), 'Jun 2026');
+	assert.equal(formatValuationDate('2023-04'), 'Apr 2023');
+	assert.equal(formatValuation(350_000), '$350K');
+	assert.equal(
+		formatPortfolioValuation({ amountUsd: 8_500_000, maxAmountUsd: 10_000_000 }),
+		'$8.5M–$10M'
+	);
+	assert.equal(formatPortfolioValuation({ amountUsd: 409_010_000, prefix: '≈' }), '≈$409.01M');
 });


### PR DESCRIPTION
## Changes

- Restore all 57 entries' exact original tiers in a new Status / tier column and composable tier filter.
- Expand public valuation coverage from 16 to 23 companies, retaining historical dates, source links, database ranges, and explicit filing-derived estimate labels.
- Add separate funding disclosures for 22 additional entries without public valuations. Raised amounts, cumulative funding, and undisclosed amounts are distinguished; acquisition prices are not valuations.
- Document company-by-company research, entity checks, and rejected estimates in docs/portfolio-research.md.
- Preserve existing logos, notes, responsive table semantics, and unrelated archive changes.

## Verification

- 434 Node tests pass, including exact original tier membership and funding/valuation separation.
- npm run check: 0 errors, 0 warnings.
- npm run build: passed.
- Published Git tree exactly matches the locally tested tree: 6164ab31aed09f0ab6d02d0dda1d6a8c6682f990.

Deployment and live browser verification will follow the merge. No dependencies or Cloudflare bindings changed.
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/swyxio/swyxdotio/pull/563?analyze=true)

<a href="https://staging.itsdev.in/review/swyxio/swyxdotio/pull/563" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-staging-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-staging-light.svg?v=3" alt="Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/swyxio/swyxdotio/pull/563" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->