### PR TITLE
Remove AI budget caps and usage notices for the verified tools owner

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,6 +454,12 @@ There is no password-login endpoint or legacy session fallback.
 - Cloud AI is **site-funded for every signed-in account**, with durable admission
   limits enforced before provider calls: 20 assistant turns/hour, 5 media jobs/hour,
   $2/day per account and $20/day site-wide in conservative estimated reservations.
+  These caps apply to non-owner accounts. The server-configured Google owner is
+  exempt from account/site quotas, assistant spending caps, and generation-run
+  caps; owner spending does not consume the shared non-owner allowance. The
+  exemption is bound to `TOOLS_OWNER_GOOGLE_SUB`, never an email or client flag.
+  Owner UI suppresses funding, logging, provider-sharing and budget notices, but
+  activity remains logged and actual errors and data-loss warnings remain visible.
   These estimates are not exact provider billing caps. Failed attempts retain their
   reservations. Provider job IDs are bound to their originating Google account.
 - AI admission/status logs contain account ID, request ID, model, timestamp, status

--- a/src/lib/DrawAgent.svelte
+++ b/src/lib/DrawAgent.svelte
@@ -18,6 +18,7 @@
 
 	/** @type {{
 	 *  authenticated?: boolean,
+	 *  isOwner?: boolean,
 	 *  userId?: string,
 	 *  pageId: string,
 	 *  open?: boolean,
@@ -31,6 +32,7 @@
 	 * }} */
 	let {
 		authenticated = false,
+		isOwner = false,
 		userId,
 		pageId,
 		executeCommand,
@@ -164,11 +166,10 @@
 
 	/** @param {number} amount @param {string} label */
 	function reserveSpending(amount, label) {
-		if (
-			!Number.isFinite(amount) ||
-			amount < 0 ||
-			spending + amount > spendingCap + Number.EPSILON
-		) {
+		if (!Number.isFinite(amount) || amount < 0) {
+			throw new Error(`${label} has an invalid cost estimate.`);
+		}
+		if (!isOwner && spending + amount > spendingCap + Number.EPSILON) {
 			throw new Error(
 				`${label} would exceed the $${spendingCap.toFixed(2)} assistant spending cap.`
 			);
@@ -296,14 +297,21 @@
 						provider: provider.id,
 						messages: conversation,
 						...(screenshot ? { screenshot } : {}),
-						...(budgetToken ? { budget: budgetToken } : { budgetCap: Number(spendingCap) })
+						...(!isOwner
+							? budgetToken
+								? { budget: budgetToken }
+								: { budgetCap: Number(spendingCap) }
+							: {})
 					}),
 					signal: operation.signal
 				});
 				const result = await response.json().catch(() => ({}));
 				if (!response.ok)
 					throw new Error(result.error ?? 'The drawing assistant could not respond.');
-				if (typeof result.budget === 'string') updateBudget(result.budget, result.spendingUsd);
+				if (!isOwner && typeof result.budget === 'string')
+					updateBudget(result.budget, result.spendingUsd);
+				else if (isOwner && Number.isFinite(result.modelCostUsd) && result.modelCostUsd >= 0)
+					spending += result.modelCostUsd;
 				const calls = Array.isArray(result.toolCalls) ? result.toolCalls : [];
 				if (!calls.length) {
 					appendMessage('assistant', result.content || 'Done.');
@@ -568,7 +576,7 @@
 			</div>
 		{:else}
 			<div class="assistant-content" bind:this={transcript}>
-				<ToolsAiNotice />
+				<ToolsAiNotice {isOwner} />
 				<div class="provider-settings">
 					<label for="drawing-provider">Drawing model</label>
 					<select
@@ -592,18 +600,20 @@
 					{#if selectedProvider && !selectedProvider.configured}<span
 							>{selectedProvider.reason}</span
 						>{/if}
-					<small>Keys are configured by the site owner, never stored in your browser.</small>
-					{#if selectedProvider?.notice}<small>{selectedProvider.notice}</small>{/if}
+					{#if !isOwner}<small
+							>Keys are configured by the site owner, never stored in your browser.</small
+						>
+						{#if selectedProvider?.notice}<small>{selectedProvider.notice}</small>{/if}{/if}
 				</div>
-				<div class="assistant-disclosure">
-					{#if selectedProvider?.configured}
-						Prompts and drawing tool results are sent to {selectedProvider.label}.
-						{#if selectedProvider.vision}Visible canvas screenshots are sent to {selectedProvider.label}.
-						{:else}Text-only: uses native scene text and geometry; no screenshot is sent.{/if}
-					{/if}
-					Image generation may also upload selected images to fal.ai. Usage shown is an estimate; provider
-					plans and discounts may differ.
-				</div>
+				{#if !isOwner}<div class="assistant-disclosure">
+						{#if selectedProvider?.configured}
+							Prompts and drawing tool results are sent to {selectedProvider.label}.
+							{#if selectedProvider.vision}Visible canvas screenshots are sent to {selectedProvider.label}.
+							{:else}Text-only: uses native scene text and geometry; no screenshot is sent.{/if}
+						{/if}
+						Image generation may also upload selected images to fal.ai. Usage shown is an estimate; provider
+						plans and discounts may differ.
+					</div>{/if}
 				{#if showWorkflowPicker && messages.length}
 					<div class="workflow-picker" aria-label="Suggested design tasks">
 						{#each workflows as workflow (workflow.id)}
@@ -702,18 +712,20 @@
 					}}
 				></textarea>
 				<div class="composer-footer">
-					<label>
-						<select
-							aria-label="Assistant spending limit"
-							bind:value={spendingCap}
-							disabled={running}
-						>
-							<option value={0.25}>$0.25 max</option>
-							<option value={0.5}>$0.50 max</option>
-							<option value={1}>$1.00 max</option>
-						</select>
-					</label>
-					{#if spending}<span class="spending">≈${spending.toFixed(4)} used</span>{/if}
+					{#if !isOwner}<label>
+							<select
+								aria-label="Assistant spending limit"
+								bind:value={spendingCap}
+								disabled={running}
+							>
+								<option value={0.25}>$0.25 max</option>
+								<option value={0.5}>$0.50 max</option>
+								<option value={1}>$1.00 max</option>
+							</select>
+						</label>{/if}
+					{#if spending}<span class="spending"
+							>≈${spending.toFixed(4)} {isOwner ? 'model calls' : 'used'}</span
+						>{/if}
 					{#if running}
 						<button type="button" class="stop-button" onclick={stop}>Stop</button>
 					{:else}

--- a/src/lib/DrawCreativeWorkspace.svelte
+++ b/src/lib/DrawCreativeWorkspace.svelte
@@ -55,7 +55,7 @@
 		onGenerate,
 		onOpenChange
 	} = $props<{
-		user: { id: string; email: string } | null;
+		user: { id: string; email: string; isOwner?: boolean } | null;
 		onInsert: (recipe: any) => Promise<void>;
 		onInsertAsset: (asset: CreativeAsset) => Promise<void>;
 		onBlank: () => void;
@@ -1511,13 +1511,13 @@
 								/></label
 							>
 							{#if sourcePlan.error}<p class="notice" role="alert">{sourcePlan.error}</p>{/if}
-							<p class="notice">
-								Extraction sends only the current transcript chunk and hints to the shared AI
-								service. Titles send your selected exact quotes and hints. Each request reserves ${TOOLS_AI_POLICY.assistantReservationUsd.toFixed(
-									2
-								)} against shared funded AI limits; this is not actual provider billing. No images are
-								generated. Stop prevents further requests; an in-flight request may still use quota.
-							</p>
+							{#if !user?.isOwner}<p class="notice">
+									Extraction sends only the current transcript chunk and hints to the shared AI
+									service. Titles send your selected exact quotes and hints. Each request reserves ${TOOLS_AI_POLICY.assistantReservationUsd.toFixed(
+										2
+									)} against shared funded AI limits; this is not actual provider billing. No images are
+									generated. Stop prevents further requests; an in-flight request may still use quota.
+								</p>{/if}
 							<label
 								>Maximum chunks this run<select disabled={busy} bind:value={maxSourceChunks}
 									>{#each [1, 2, 4, 8] as count}<option value={count}>{count} chunks</option
@@ -1528,8 +1528,8 @@
 									{sourcePlan.plan.remaining} chunks remaining. This click: up to {sourcePlan.plan
 										.run.length} requests · ${sourcePlan.plan.estimatedRunUsd.toFixed(2)} reserved. All
 									remaining chunks: ${sourcePlan.plan.estimatedRemainingUsd.toFixed(2)}; titles are
-									a separate ${TOOLS_AI_POLICY.assistantReservationUsd.toFixed(2)} request. Quota limits
-									can pause the run.
+									a separate ${TOOLS_AI_POLICY.assistantReservationUsd.toFixed(2)} request.{#if !user?.isOwner}
+										Quota limits can pause the run.{/if}
 								</p>{/if}
 							<div class="actions">
 								<button

--- a/src/lib/DrawImageToolbox.svelte
+++ b/src/lib/DrawImageToolbox.svelte
@@ -45,6 +45,7 @@
 	 *  captureUpdate: typeof import('@excalidraw/excalidraw').CaptureUpdateAction.IMMEDIATELY,
 	 *  cloudAvailable?: boolean,
 	 *  authenticated?: boolean,
+	 *  isOwner?: boolean,
 	 *  userId?: string,
 	 *  onCloudLimit?: () => void,
 	 *  backgroundProcessing?: boolean,
@@ -72,6 +73,7 @@
 		captureUpdate,
 		cloudAvailable = false,
 		authenticated = false,
+		isOwner = false,
 		userId,
 		onCloudLimit,
 		backgroundProcessing = false,
@@ -856,7 +858,7 @@
 			const run = createDrawingGenerationRun({
 				pageKey,
 				recipes,
-				limitUsd: retry?.limitUsd ?? Number(runLimitUsd),
+				limitUsd: isOwner ? null : (retry?.limitUsd ?? Number(runLimitUsd)),
 				id: retry?.id
 			});
 			const estimate = recipes.reduce((total, recipe) => {
@@ -872,6 +874,7 @@
 				);
 			}, 0);
 			if (
+				!isOwner &&
 				estimate >= Number(confirmationThreshold) &&
 				!confirm(
 					`Generate ${recipes.length} result(s) for approximately $${estimate.toFixed(3)}? Funded by swyx.io. This is an estimate, not final provider billing. References will be sent to the selected providers.`
@@ -1080,9 +1083,11 @@
 			<strong>{imageId ? 'Image tools' : 'Generate'}</strong>
 			<span>
 				{action === 'generate'
-					? uploadsSelectedImage
-						? `Uploads the reference to ${[...new Set(selectedModels.map((model) => model.transportLabel))].join(', ')}`
-						: 'Prompt only · no image upload'
+					? isOwner
+						? 'Image and video generation'
+						: uploadsSelectedImage
+							? `Uploads the reference to ${[...new Set(selectedModels.map((model) => model.transportLabel))].join(', ')}`
+							: 'Prompt only · no image upload'
 					: action
 						? 'Runs privately on your device'
 						: 'Choose a tool'}
@@ -1555,14 +1560,14 @@
 						<strong>{selectedModel.badge}</strong>
 					</div>
 				{/if}
-				<p class="fal-upload-hint">
-					{authenticated ? 'Funded by swyx.io · ' : 'Sign in required · '}
-					{uploadsSelectedImage
-						? 'Large images automatically fit each model’s limits and the secure upload limit.'
-						: 'Text-to-image workflows only send your prompt; no reference image is uploaded.'}
-				</p>
+				{#if !isOwner}<p class="fal-upload-hint">
+						{authenticated ? 'Funded by swyx.io · ' : 'Sign in required · '}
+						{uploadsSelectedImage
+							? 'Large images automatically fit each model’s limits and the secure upload limit.'
+							: 'Text-to-image workflows only send your prompt; no reference image is uploaded.'}
+					</p>{/if}
 			</div>
-			<ToolsAiNotice />
+			<ToolsAiNotice {isOwner} />
 			{#each selectedWorkflowParameters as folder (folder.kind)}
 				{#if folder.parameters.length}
 					<section class="fal-parameter-group" aria-label="{folder.label} settings">
@@ -1645,37 +1650,37 @@
 					</section>
 				{/if}
 			{/each}
-			<div class="generation-budget">
-				<label
-					>Run reservation limit ($)<input
-						aria-label="Run spending limit"
-						type="number"
-						min="0.05"
-						max="20"
-						step="0.05"
-						bind:value={runLimitUsd}
-						disabled={processingGeneration}
-					/></label
-				>
-				<label
-					>Confirm estimates above ($)<input
-						aria-label="Generation confirmation threshold"
-						type="number"
-						min="0"
-						max="20"
-						step="0.05"
-						bind:value={confirmationThreshold}
-						disabled={processingGeneration}
-					/></label
-				>
-				<p>
-					Reserves ~${reservationTotal.toFixed(3)} against the run limit. Estimates are not final provider
-					billing. Account/site limits also apply.
-				</p>
-				{#each [...new Set(selectedModels.map((model) => model.disclosure))] as disclosure}<p>
-						{disclosure}
-					</p>{/each}
-			</div>
+			{#if !isOwner}<div class="generation-budget">
+					<label
+						>Run reservation limit ($)<input
+							aria-label="Run spending limit"
+							type="number"
+							min="0.05"
+							max="20"
+							step="0.05"
+							bind:value={runLimitUsd}
+							disabled={processingGeneration}
+						/></label
+					>
+					<label
+						>Confirm estimates above ($)<input
+							aria-label="Generation confirmation threshold"
+							type="number"
+							min="0"
+							max="20"
+							step="0.05"
+							bind:value={confirmationThreshold}
+							disabled={processingGeneration}
+						/></label
+					>
+					<p>
+						Reserves ~${reservationTotal.toFixed(3)} against the run limit. Estimates are not final provider
+						billing. Account/site limits also apply.
+					</p>
+					{#each [...new Set(selectedModels.map((model) => model.disclosure))] as disclosure}<p>
+							{disclosure}
+						</p>{/each}
+				</div>{/if}
 			<div class="fal-action-row">
 				<span>
 					{selectedModels.length
@@ -1698,7 +1703,7 @@
 							!prompt.trim() ||
 							!selectedModels.length ||
 							(uploadsSelectedImage && !activeReference) ||
-							reservationTotal > Number(runLimitUsd)}
+							(!isOwner && reservationTotal > Number(runLimitUsd))}
 						onclick={() => void applyGeneration()}
 					>
 						{selectedWorkflowKind === 'image-to-video'
@@ -1905,7 +1910,8 @@
 					>Cancel remaining jobs</button
 				>{:else if generationJobs.some((job) => job.status === 'failed')}<button
 					type="button"
-					onclick={() => applyGeneration(true)}>Retry failed jobs (same run budget)</button
+					onclick={() => applyGeneration(true)}
+					>{isOwner ? 'Retry failed jobs' : 'Retry failed jobs (same run budget)'}</button
 				>{/if}
 		</section>
 	{/if}

--- a/src/lib/ToolsAiNotice.svelte
+++ b/src/lib/ToolsAiNotice.svelte
@@ -1,19 +1,20 @@
 <script>
 	import { TOOLS_AI_POLICY } from '$lib/tools-ai-policy.js';
+	export let isOwner = false;
 </script>
 
-<aside class="ai-notice" aria-label="Funded AI usage notice">
-	<strong>AI is funded by swyx.io, rate limited, and logged.</strong>
-	<span>Signed-in tool actions are also recorded in <a href="/tools/logs">Tool logs</a>.</span>
-	<span>
-		{TOOLS_AI_POLICY.assistantTurnsPerHour} assistant turns and
-		{TOOLS_AI_POLICY.mediaJobsPerHour} generations per hour per account; ${TOOLS_AI_POLICY.userEstimatedDailyUsd}/day
-		estimated allowance. Account, model, time, status, and estimated-cost logs are kept for
-		{TOOLS_AI_POLICY.retentionDays} days—not prompts or images. The site owner can review everyone’s usage
-		metadata and account identity.
-		<a href="/tools/privacy">Details</a>
-	</span>
-</aside>
+{#if !isOwner}<aside class="ai-notice" aria-label="Funded AI usage notice">
+		<strong>AI is funded by swyx.io, rate limited, and logged.</strong>
+		<span>Signed-in tool actions are also recorded in <a href="/tools/logs">Tool logs</a>.</span>
+		<span>
+			{TOOLS_AI_POLICY.assistantTurnsPerHour} assistant turns and
+			{TOOLS_AI_POLICY.mediaJobsPerHour} generations per hour per account; ${TOOLS_AI_POLICY.userEstimatedDailyUsd}/day
+			estimated allowance. Account, model, time, status, and estimated-cost logs are kept for
+			{TOOLS_AI_POLICY.retentionDays} days—not prompts or images. The site owner can review everyone’s
+			usage metadata and account identity.
+			<a href="/tools/privacy">Details</a>
+		</span>
+	</aside>{/if}
 
 <style>
 	.ai-notice {

--- a/src/lib/ToolsUsageReceipt.svelte
+++ b/src/lib/ToolsUsageReceipt.svelte
@@ -1,13 +1,14 @@
 <script>
 	import { TOOLS_AI_POLICY } from '$lib/tools-ai-policy.js';
 	export let signedIn = false;
+	export let isOwner = false;
 	/** @type {{assistantTurnsThisHour:number,mediaJobsThisHour:number,estimatedReservedTodayUsd:number}|null} */
 	export let usage = null;
 	export let unavailable = false;
 </script>
 
-<aside class="receipt" aria-label="Usage allowance">
-	<p class="receipt-title">Today's allowance</p>
+<aside class="receipt" aria-label={isOwner ? 'Usage summary' : 'Usage allowance'}>
+	<p class="receipt-title">{isOwner ? "Today's usage" : "Today's allowance"}</p>
 	{#if signedIn}
 		<section
 			class="counters"
@@ -17,24 +18,28 @@
 		>
 			{#if usage}
 				<p>
-					<b>{usage.assistantTurnsThisHour} / {TOOLS_AI_POLICY.assistantTurnsPerHour}</b><span
-						>assistant turns this hour</span
-					>
+					<b
+						>{usage.assistantTurnsThisHour}{isOwner
+							? ''
+							: ` / ${TOOLS_AI_POLICY.assistantTurnsPerHour}`}</b
+					><span>assistant turns this hour</span>
 				</p>
 				<p>
-					<b>{usage.mediaJobsThisHour} / {TOOLS_AI_POLICY.mediaJobsPerHour}</b><span
-						>generations this hour</span
-					>
+					<b>{usage.mediaJobsThisHour}{isOwner ? '' : ` / ${TOOLS_AI_POLICY.mediaJobsPerHour}`}</b
+					><span>generations this hour</span>
 				</p>
 				<p>
 					<b
-						>${usage.estimatedReservedTodayUsd.toFixed(2)} / ${TOOLS_AI_POLICY.userEstimatedDailyUsd.toFixed(
-							2
-						)}</b
+						>${usage.estimatedReservedTodayUsd.toFixed(2)}{isOwner
+							? ''
+							: ` / $${TOOLS_AI_POLICY.userEstimatedDailyUsd.toFixed(2)}`}</b
 					><span>estimated reserved today</span>
 				</p>
 			{:else if unavailable}
-				<p class="usage-state">Usage is temporarily unavailable. Server limits still apply.</p>
+				<p class="usage-state">
+					Usage is temporarily unavailable.{#if !isOwner}
+						Server limits still apply.{/if}
+				</p>
 			{:else}
 				<p class="usage-state">Loading your usage…</p>
 			{/if}
@@ -45,13 +50,13 @@
 			generations / hour<br />${TOOLS_AI_POLICY.userEstimatedDailyUsd} estimated daily allowance
 		</p>
 	{/if}
-	<div class="disclosure">
-		<strong>AI is funded by swyx.io, rate limited, and logged.</strong>
-		<p>
-			Signed-in tool activity is logged too. The site owner can review usage metadata and account
-			identity.
-		</p>
-	</div>
+	{#if !isOwner}<div class="disclosure">
+			<strong>AI is funded by swyx.io, rate limited, and logged.</strong>
+			<p>
+				Signed-in tool activity is logged too. The site owner can review usage metadata and account
+				identity.
+			</p>
+		</div>{/if}
 </aside>
 
 <style>

--- a/src/lib/draw-generation-batch.js
+++ b/src/lib/draw-generation-batch.js
@@ -10,15 +10,15 @@ import { estimateToolsMediaReservation } from './tools-ai-policy.js';
 /** @typedef {import('./draw-generation-history.js').DrawingImageGeneration} Generation */
 /** @typedef {{id:string,prompt:string,modelId:string,adapterId:string,modelSettings:Record<string,unknown>,referenceImages:import('./draw-generation-history.js').DrawingGenerationReference[],parentGenerationId?:string,context?:Record<string,unknown>}} DrawingGenerationRecipe */
 /** @typedef {{id:string,runId:string,recipe:DrawingGenerationRecipe,status:'pending'|'running'|'completed'|'failed'|'stopped',message:string,requestId?:string,elapsedMs?:number,error?:string,generation?:Generation}} DrawingGenerationJob */
-/** @typedef {{id:string,createdAt:number,pageKey:string,limitUsd:number,jobs:DrawingGenerationJob[]}} DrawingGenerationRun */
+/** @typedef {{id:string,createdAt:number,pageKey:string,limitUsd:number|null,jobs:DrawingGenerationJob[]}} DrawingGenerationRun */
 
 /** A run owns immutable recipe snapshots; tool/mode changes never rewrite them.
- * @param {{pageKey:string,recipes:DrawingGenerationRecipe[],limitUsd:number,id?:string}} options
+ * @param {{pageKey:string,recipes:DrawingGenerationRecipe[],limitUsd:number|null,id?:string}} options
  * @returns {DrawingGenerationRun}
  */
 export function createDrawingGenerationRun(options) {
 	if (!options.pageKey || !options.recipes.length) throw new Error('Choose at least one model.');
-	if (!Number.isFinite(options.limitUsd) || options.limitUsd <= 0)
+	if (options.limitUsd !== null && (!Number.isFinite(options.limitUsd) || options.limitUsd <= 0))
 		throw new Error('Choose a positive run spending limit.');
 	const id = options.id ?? crypto.randomUUID();
 	const recipes = structuredClone(options.recipes);
@@ -37,7 +37,7 @@ export function createDrawingGenerationRun(options) {
 		const effective = resolveDrawGenerationModelSettings(model, recipe.modelSettings);
 		reserved += estimateToolsMediaReservation(estimateDrawGenerationModelCost(model, effective));
 	}
-	if (reserved > options.limitUsd + 0.000001)
+	if (options.limitUsd !== null && reserved > options.limitUsd + 0.000001)
 		throw new Error(
 			`This batch reserves ~$${reserved.toFixed(3)}, above your $${options.limitUsd.toFixed(2)} run limit.`
 		);

--- a/src/lib/draw-generation-client.js
+++ b/src/lib/draw-generation-client.js
@@ -54,7 +54,7 @@ async function readResponse(response) {
  *  agentBudget?: string
  *  onBudget?: (budget: string, spendingUsd: number) => void
  *  runId?: string
- *  runLimitUsd?: number
+ *  runLimitUsd?: number | null
  *  clientJobId?: string
  *  cancelOnAbort?: boolean
  * }} options

--- a/src/lib/server/draw-agent.js
+++ b/src/lib/server/draw-agent.js
@@ -190,7 +190,7 @@ function hasCompletedToolReview(messages) {
 
 /**
  * One bounded model turn. Browser-side tools remain outside the Worker and its
- * secrets; every signed-in account uses the same durable funded-usage limits.
+ * secrets; all requests are logged, and non-owner accounts have funded-usage limits.
  * @param {Pick<import('@sveltejs/kit').RequestEvent, 'cookies' | 'platform' | 'request' | 'url'>} event
  */
 export async function runDrawingAgent(event) {
@@ -292,20 +292,25 @@ export async function runDrawingAgent(event) {
 			{ status: error instanceof DrawingProviderError ? error.status : 503 }
 		);
 	}
-	/** @type {string} */
+	/** @type {string | undefined} */
 	let budget;
-	try {
-		budget = body.budget
-			? body.budget
-			: await createDrawingAgentBudget(body.budgetCap ?? 1, sessionSecret);
-		await chargeDrawingAgentBudget(budget, stepReserve, sessionSecret);
-	} catch (error) {
-		return privateJson(
-			{
-				error: error instanceof Error ? error.message : 'The assistant spending limit was reached.'
-			},
-			{ status: 402 }
-		);
+	if (!user.isOwner) {
+		try {
+			budget = body.budget
+				? body.budget
+				: await createDrawingAgentBudget(body.budgetCap ?? 1, sessionSecret);
+			if (typeof budget !== 'string')
+				throw new Error('The assistant spending authorization is invalid.');
+			await chargeDrawingAgentBudget(budget, stepReserve, sessionSecret);
+		} catch (error) {
+			return privateJson(
+				{
+					error:
+						error instanceof Error ? error.message : 'The assistant spending limit was reached.'
+				},
+				{ status: 402 }
+			);
+		}
 	}
 	if (provider.vision && body.screenshot) {
 		messages.push({
@@ -407,19 +412,22 @@ export async function runDrawingAgent(event) {
 			);
 		}
 	}
-	try {
-		const charged = await chargeDrawingAgentBudget(budget, modelCostUsd, sessionSecret);
-		response.budget = charged.token;
-		response.spendingUsd = charged.spendingUsd;
-		response.modelCostUsd = modelCostUsd;
-	} catch (error) {
-		await finishToolsAiUsage(event, user.id, reservation.id, 'failed');
-		return privateJson(
-			{
-				error: error instanceof Error ? error.message : 'The assistant spending limit was reached.'
-			},
-			{ status: 402 }
-		);
+	response.modelCostUsd = modelCostUsd;
+	if (budget) {
+		try {
+			const charged = await chargeDrawingAgentBudget(budget, modelCostUsd, sessionSecret);
+			response.budget = charged.token;
+			response.spendingUsd = charged.spendingUsd;
+		} catch (error) {
+			await finishToolsAiUsage(event, user.id, reservation.id, 'failed');
+			return privateJson(
+				{
+					error:
+						error instanceof Error ? error.message : 'The assistant spending limit was reached.'
+				},
+				{ status: 402 }
+			);
+		}
 	}
 	const recorded = await finishToolsAiUsage(event, user.id, reservation.id, 'succeeded');
 	if (!recorded.ok) return recorded;

--- a/src/lib/server/draw-generation.js
+++ b/src/lib/server/draw-generation.js
@@ -41,21 +41,20 @@ function generationError(error, fallback) {
 	);
 }
 
-/** @param {FormData} form */
-function runAuthorization(form) {
+/** @param {FormData} form @param {boolean} isOwner */
+function runAuthorization(form, isOwner) {
 	const runId = form.get('runId');
 	const clientJobId = form.get('clientJobId');
 	const rawLimit = form.get('runLimitUsd');
 	if (runId === null && clientJobId === null && rawLimit === null) return undefined;
-	const limitUsd = typeof rawLimit === 'string' ? Number(rawLimit) : NaN;
+	const limitUsd = isOwner ? null : typeof rawLimit === 'string' ? Number(rawLimit) : NaN;
 	if (
 		typeof runId !== 'string' ||
 		!REQUEST_ID.test(runId) ||
 		typeof clientJobId !== 'string' ||
 		!REQUEST_ID.test(clientJobId) ||
-		!Number.isFinite(limitUsd) ||
-		limitUsd <= 0 ||
-		limitUsd > 100
+		(!isOwner &&
+			(limitUsd === null || !Number.isFinite(limitUsd) || limitUsd <= 0 || limitUsd > 100))
 	)
 		throw new DrawingGenerationError(
 			'Choose a valid run spending limit.',
@@ -167,7 +166,7 @@ export async function editDrawingImage(event, fetchProvider = fetch) {
 		);
 	let run;
 	try {
-		run = runAuthorization(form);
+		run = runAuthorization(form, user.isOwner);
 	} catch (error) {
 		return generationError(error, 'The run spending limit is invalid.');
 	}
@@ -194,7 +193,7 @@ export async function editDrawingImage(event, fetchProvider = fetch) {
 		);
 	}
 	const agentBudget = form.get('agentBudget');
-	if ((providerSafetyDefaults === '1') !== (typeof agentBudget === 'string')) {
+	if (!user.isOwner && (providerSafetyDefaults === '1') !== (typeof agentBudget === 'string')) {
 		return privateJson(
 			{ error: 'The assistant requires an authorized spending limit.' },
 			{ status: 402 }
@@ -202,7 +201,7 @@ export async function editDrawingImage(event, fetchProvider = fetch) {
 	}
 	/** @type {{ token: string, spendingUsd: number } | undefined} */
 	let chargedBudget;
-	if (typeof agentBudget === 'string') {
+	if (!user.isOwner && typeof agentBudget === 'string') {
 		try {
 			chargedBudget = await chargeDrawingAgentBudget(
 				agentBudget,

--- a/src/lib/server/tools-ai-usage.js
+++ b/src/lib/server/tools-ai-usage.js
@@ -16,7 +16,11 @@ export async function toolsAiLedger(event, path, body) {
 			new Request(`https://drawing.internal/ai/${path}`, {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify(body),
+				body: JSON.stringify({
+					...body,
+					// This private binding never accepts an owner identity from the browser.
+					ownerUserId: event.platform?.env?.TOOLS_OWNER_GOOGLE_SUB ?? null
+				}),
 				signal: AbortSignal.timeout(10_000)
 			})
 		);
@@ -36,11 +40,16 @@ export async function toolsAiLedger(event, path, body) {
 	}
 }
 
-/** @param {UsageEvent & Pick<import('@sveltejs/kit').RequestEvent, 'cookies'>} event @param {string} userId @param {'assistant'|'media'} kind @param {string} model @param {number} estimatedReservedUsd @param {{id: string, clientJobId: string, limitUsd: number}} [run] */
+/** @param {UsageEvent & Pick<import('@sveltejs/kit').RequestEvent, 'cookies'>} event @param {string} userId @param {'assistant'|'media'} kind @param {string} model @param {number} estimatedReservedUsd @param {{id: string, clientJobId: string, limitUsd: number | null}} [run] */
 export async function reserveToolsAiUsage(event, userId, kind, model, estimatedReservedUsd, run) {
 	const user = await getToolsUser(event);
-	const profile =
-		user?.id === userId ? { id: user.id, email: user.email, name: user.name } : undefined;
+	if (!user) return privateJson({ error: 'Sign in to use AI.' }, { status: 401 });
+	if (user.id !== userId)
+		return privateJson(
+			{ error: 'Your Google account changed. Reload before continuing.' },
+			{ status: 409 }
+		);
+	const profile = { id: user.id, email: user.email, name: user.name };
 	const result = await toolsAiLedger(event, 'admit', {
 		userId,
 		kind,

--- a/src/routes/tools/+page.svelte
+++ b/src/routes/tools/+page.svelte
@@ -120,7 +120,12 @@
 				<a class="continue" href={data.next}>Continue to your tool →</a>
 			{/if}
 		</div>
-		<ToolsUsageReceipt signedIn={!!data.user} usage={aiUsage} unavailable={usageUnavailable} />
+		<ToolsUsageReceipt
+			signedIn={!!data.user}
+			isOwner={!!data.user?.isOwner}
+			usage={aiUsage}
+			unavailable={usageUnavailable}
+		/>
 	</div>
 	{#if !data.user}
 		<div class="signin-strip">
@@ -161,24 +166,21 @@
 		</div>
 	{/if}
 	<div class="workshop-scene"><ToolsCabinet isOwner={!!data.user?.isOwner} /></div>
-	<details class="workshop-rules">
-		<summary
-			><span>The rules of the workshop</span><span class="rules-hint"
-				>{TOOLS_AI_POLICY.retentionDays}-day metadata logs · no prompts or images in logs</span
-			></summary
-		>
-		<ToolsAiNotice />
-		<p>
-			The daily estimated allowance is ${TOOLS_AI_POLICY.userEstimatedDailyUsd} per account, with a ${TOOLS_AI_POLICY.siteEstimatedDailyUsd}
-			site-wide guard. Daily limits reset at midnight UTC. Reservations are conservative estimates, not
-			provider invoices.
-		</p>
-		{#if data.user?.isOwner}<p>
-				As site owner, you can select Everyone in <a href="/tools/logs">Tool logs</a> to review account
-				identities and activity metadata—not private prompts or assets.
-			</p>{/if}
-		<p><a href="/tools/privacy">Privacy and full details →</a></p>
-	</details>
+	{#if !data.user?.isOwner}<details class="workshop-rules">
+			<summary
+				><span>The rules of the workshop</span><span class="rules-hint"
+					>{TOOLS_AI_POLICY.retentionDays}-day metadata logs · no prompts or images in logs</span
+				></summary
+			>
+			<ToolsAiNotice />
+			<p>
+				The daily estimated allowance is ${TOOLS_AI_POLICY.userEstimatedDailyUsd} per account, with a
+				${TOOLS_AI_POLICY.siteEstimatedDailyUsd}
+				site-wide guard. Daily limits reset at midnight UTC. Reservations are conservative estimates,
+				not provider invoices.
+			</p>
+			<p><a href="/tools/privacy">Privacy and full details →</a></p>
+		</details>{/if}
 </section>
 
 <style>

--- a/src/routes/tools/box/+page.svelte
+++ b/src/routes/tools/box/+page.svelte
@@ -2,6 +2,7 @@
 	import { onMount } from 'svelte';
 	import { recordToolActivity } from '$lib/tools-activity-client.js';
 	let signedIn = false;
+	let isOwner = false;
 	onMount(() => {
 		const abort = new AbortController();
 		void fetch('/tools/api/session', { cache: 'no-store', signal: abort.signal })
@@ -10,6 +11,7 @@
 				const session = await response.json();
 				if (abort.signal.aborted) return;
 				signedIn = Boolean(session.user);
+				isOwner = Boolean(session.user?.isOwner);
 				void recordToolActivity(session.user?.id, 'box.open');
 			})
 			.catch(() => {});
@@ -28,7 +30,7 @@
 	<!-- svelte-ignore a11y_autofocus (the dedicated writing canvas should be immediately editable) -->
 	<textarea autofocus aria-label="Write anything" spellcheck="false"></textarea>
 	<footer>
-		<a href="/">swyx.io</a>{#if signedIn}<a class="logging-note" href="/tools/logs"
+		<a href="/">swyx.io</a>{#if signedIn && !isOwner}<a class="logging-note" href="/tools/logs"
 				>Tool opens are logged · visible to you and swyx · text stays here</a
 			>{/if}
 	</footer>

--- a/src/routes/tools/draw/+page.svelte
+++ b/src/routes/tools/draw/+page.svelte
@@ -1195,7 +1195,8 @@
 						});
 			const generationModel = model;
 			const agentBudget = operation.getBudget();
-			if (!agentBudget) throw new Error('The assistant spending authorization is unavailable.');
+			if (!toolsUser?.isOwner && !agentBudget)
+				throw new Error('The assistant spending authorization is unavailable.');
 			const generated = await runDrawingGeneration({
 				userId: toolsUser?.id,
 				image: prepared?.blob,
@@ -1203,8 +1204,7 @@
 				model: model.id,
 				signal: operation.signal,
 				providerSafetyDefaults: true,
-				agentBudget,
-				onBudget: operation.updateBudget,
+				...(!toolsUser?.isOwner ? { agentBudget, onBudget: operation.updateBudget } : {}),
 				cancelOnAbort: true,
 				onProgress: (progress) =>
 					operation.onProgress(
@@ -2397,6 +2397,7 @@
 		{backgroundInset}
 		onOpen={() => prepareWorkspaceSurface('assistant')}
 		authenticated={toolsAuthenticated}
+		isOwner={!!toolsUser?.isOwner}
 		userId={toolsUser?.id}
 		pageId={`${STORAGE_KEY}:${activePageId}`}
 		executeCommand={executeAgentCommand}
@@ -2516,6 +2517,7 @@
 			captureUpdate={captureImmediately}
 			{cloudAvailable}
 			authenticated={toolsAuthenticated}
+			isOwner={!!toolsUser?.isOwner}
 			userId={toolsUser?.id}
 			backgroundProcessing={isRemovingBackground}
 			generations={imageGenerations}
@@ -2651,7 +2653,7 @@
 				</div>
 				{#if recoveryNotice}<p class="page-logging" role="status">{recoveryNotice}</p>{/if}
 
-				{#if toolsAuthenticated}<p class="page-logging">
+				{#if toolsAuthenticated && !toolsUser?.isOwner}<p class="page-logging">
 						<a href="/tools/logs">Tool activity is logged</a> · visible to you and swyx; drawing contents
 						stay private.
 					</p>{/if}

--- a/src/routes/tools/privacy/+page.svelte
+++ b/src/routes/tools/privacy/+page.svelte
@@ -43,12 +43,14 @@
 		entries expire after 30 days; this dashboard does not collect usage from external apps.
 	</p>
 	<p>
-		Every account, including the site owner, is limited to {TOOLS_AI_POLICY.assistantTurnsPerHour} assistant
-		model turns and {TOOLS_AI_POLICY.mediaJobsPerHour} media generations per hour. Each account has a
-		${TOOLS_AI_POLICY.userEstimatedDailyUsd} daily estimated-cost allowance, with a ${TOOLS_AI_POLICY.siteEstimatedDailyUsd}
+		Non-owner accounts are limited to {TOOLS_AI_POLICY.assistantTurnsPerHour} assistant model turns and
+		{TOOLS_AI_POLICY.mediaJobsPerHour} media generations per hour. Each account has a ${TOOLS_AI_POLICY.userEstimatedDailyUsd}
+		daily estimated-cost allowance, with a ${TOOLS_AI_POLICY.siteEstimatedDailyUsd}
 		estimated daily guard shared across the site. These are conservative reservation estimates, not exact
 		provider bills. Failed provider attempts still use a reservation. Hourly limits use a rolling one-hour
-		window; daily limits reset at midnight UTC.
+		window; daily limits reset at midnight UTC. The server-verified site owner is exempt from app usage
+		and spending limits, and owner usage does not consume this shared allowance. Owner activity is still
+		logged with the same retention and privacy rules.
 	</p>
 	<p>
 		Before making a paid request, the server records an admission and reserves quota. Operational

--- a/tests/draw-agent.spec.js
+++ b/tests/draw-agent.spec.js
@@ -4,7 +4,7 @@ import { authenticateTools, TEST_TOOLS_OWNER, TEST_TOOLS_MEMBER } from './helper
 /** @param {import('@playwright/test').Page} page */
 async function authenticate(page) {
 	const origin = new URL(page.url()).origin;
-	await authenticateTools(page);
+	await authenticateTools(page, TEST_TOOLS_MEMBER);
 	await page.reload();
 }
 
@@ -142,6 +142,7 @@ test('authenticated floating assistant uses viewport vision, sandboxed commands,
 }) => {
 	await page.goto('/tools/draw');
 	await authenticate(page);
+	/** @type {any[]} */
 	/** @type {any[]} */
 	const requests = [];
 	await page.route('**/tools/api/draw/agent', async (route) => {
@@ -404,6 +405,7 @@ test('assistant sandbox cannot execute network, JavaScript, or host-shell comman
 	await page.goto('/tools/draw');
 	await authenticate(page);
 	/** @type {any[]} */
+	/** @type {any[]} */
 	const requests = [];
 	await page.route('**/tools/api/draw/agent', async (route) => {
 		if (route.request().method() === 'GET') return route.continue();
@@ -551,4 +553,58 @@ test('assistant arranges shapes and connects them with native Excalidraw arrow b
 	expect(scene.elements.some((element) => element.type === 'text' && element.text === 'next')).toBe(
 		true
 	);
+});
+
+test('owner assistant omits spending authorization and warnings but retains request errors', async ({
+	page
+}) => {
+	await page.goto('/tools/draw');
+	await authenticateTools(page, TEST_TOOLS_OWNER);
+	await page.reload();
+	/** @type {any[]} */
+	const requests = [];
+	await page.route('**/tools/api/draw/agent', async (route) => {
+		if (route.request().method() === 'GET')
+			return route.fulfill({
+				json: {
+					providers: [
+						{
+							id: 'cloudflare',
+							label: 'Cloudflare AI',
+							model: 'Qwen',
+							vision: false,
+							configured: true,
+							notice: 'Provider sharing warning'
+						}
+					]
+				}
+			});
+		requests.push(route.request().postDataJSON());
+		await route.fulfill({
+			status: 503,
+			json: { error: 'Fixture provider is temporarily unavailable.' }
+		});
+	});
+	await page.getByRole('button', { name: 'Open drawing assistant' }).click();
+	const assistant = page.getByRole('region', { name: 'Drawing assistant' });
+	await expect(assistant.getByRole('combobox', { name: 'Drawing model' })).toBeEnabled();
+	await expect(assistant.getByRole('combobox', { name: 'Assistant spending limit' })).toHaveCount(
+		0
+	);
+	await expect(
+		assistant.getByRole('complementary', { name: 'Funded AI usage notice' })
+	).toHaveCount(0);
+	await expect(assistant.locator('.assistant-disclosure')).toHaveCount(0);
+	await expect(assistant.getByText('Provider sharing warning')).toHaveCount(0);
+	await assistant
+		.getByRole('textbox', { name: 'Message drawing assistant' })
+		.fill('Draw a small square');
+	await assistant.getByRole('button', { name: 'Send', exact: true }).click();
+	await expect(assistant.getByRole('alert')).toContainText(
+		'Fixture provider is temporarily unavailable.'
+	);
+	expect(requests).toHaveLength(1);
+	expect(requests[0]).not.toHaveProperty('budget');
+	expect(requests[0]).not.toHaveProperty('budgetCap');
+	await expect(assistant.getByRole('button', { name: 'Retry', exact: true })).toBeVisible();
 });

--- a/tests/draw-agent.test.mjs
+++ b/tests/draw-agent.test.mjs
@@ -86,6 +86,7 @@ test('drawing assistant sends only the visible viewport to the selected vision m
 	const calls = [];
 	const response = await runDrawingAgent(
 		await createEvent({
+			owner: false,
 			body: { messages: [{ role: 'user', content: 'Draw a diagram' }], screenshot: SCREENSHOT },
 			ai: {
 				run: async (...args) => {
@@ -237,6 +238,7 @@ test('truncated model output cannot execute partial commands or claim a complete
 test('drawing assistant signs shared run budgets, tracks model tokens, and rejects tampering or overspending', async () => {
 	const first = await runDrawingAgent(
 		await createEvent({
+			owner: false,
 			body: { messages: [{ role: 'user', content: 'Align the diagram' }], budgetCap: 0.25 },
 			ai: {
 				run: async () => ({
@@ -251,6 +253,7 @@ test('drawing assistant signs shared run budgets, tracks model tokens, and rejec
 	assert.equal(firstBody.spendingUsd, 0.00077);
 	const second = await runDrawingAgent(
 		await createEvent({
+			owner: false,
 			body: { messages: [{ role: 'user', content: 'Continue' }], budget: firstBody.budget },
 			ai: {
 				run: async () => ({
@@ -263,6 +266,7 @@ test('drawing assistant signs shared run budgets, tracks model tokens, and rejec
 	assert.equal((await second.json()).spendingUsd, 0.00154);
 	const invalid = await runDrawingAgent(
 		await createEvent({
+			owner: false,
 			body: {
 				messages: [{ role: 'user', content: 'Continue' }],
 				budget: `${firstBody.budget}tampered`
@@ -278,6 +282,7 @@ test('drawing assistant signs shared run budgets, tracks model tokens, and rejec
 	);
 	const blocked = await runDrawingAgent(
 		await createEvent({
+			owner: false,
 			body: { messages: [{ role: 'user', content: 'Continue' }], budget: exhausted.token },
 			ai: {
 				run: async () => {
@@ -290,7 +295,10 @@ test('drawing assistant signs shared run budgets, tracks model tokens, and rejec
 	assert.equal(blocked.status, 402);
 	assert.equal(called, false);
 	const overMaximum = await runDrawingAgent(
-		await createEvent({ body: { messages: [{ role: 'user', content: 'Continue' }], budgetCap: 5 } })
+		await createEvent({
+			owner: false,
+			body: { messages: [{ role: 'user', content: 'Continue' }], budgetCap: 5 }
+		})
 	);
 	assert.equal(overMaximum.status, 402);
 });
@@ -465,6 +473,7 @@ test('replaying a signed per-run budget cannot bypass durable per-account funded
 	for (let index = 0; index < 21; index++) {
 		const response = await runDrawingAgent(
 			await createEvent({
+				owner: false,
 				ledger,
 				ai,
 				body: { messages: [{ role: 'user', content: 'Continue' }], budget }
@@ -476,6 +485,32 @@ test('replaying a signed per-run budget cannot bypass durable per-account funded
 	assert.equal(
 		ledger.database.prepare('SELECT COUNT(*) AS count FROM tools_ai_usage').get().count,
 		20
+	);
+});
+
+test('owner assistant calls ignore spending caps without issuing a transferable unlimited budget', async () => {
+	const ledger = createTestAiLedger();
+	for (let index = 0; index < 22; index++) {
+		const response = await runDrawingAgent(
+			await createEvent({
+				ledger,
+				body: {
+					messages: [{ role: 'user', content: 'Continue' }],
+					budgetCap: 0.001,
+					budget: 'obsolete-owner-budget'
+				}
+			})
+		);
+		assert.equal(response.status, 200);
+		const body = await response.json();
+		assert.equal(body.budget, undefined);
+		assert.ok(body.modelCostUsd > 0);
+	}
+	assert.equal(
+		ledger.database
+			.prepare("SELECT COUNT(*) AS count FROM tools_ai_usage WHERE status = 'succeeded'")
+			.get().count,
+		22
 	);
 });
 

--- a/tests/draw-fal.test.mjs
+++ b/tests/draw-fal.test.mjs
@@ -238,10 +238,13 @@ test('autonomous drawing-agent edits preserve provider-managed safety defaults',
 		});
 		/** @type {Record<string, unknown> | undefined} */
 		let payload;
-		const response = await editDrawingImage(await createEvent({ form }), async (_url, init) => {
-			payload = JSON.parse(/** @type {string} */ (init?.body));
-			return providerResponse({ request_id: REQUEST_ID }, 202);
-		});
+		const response = await editDrawingImage(
+			await createEvent({ owner: false, form }),
+			async (_url, init) => {
+				payload = JSON.parse(/** @type {string} */ (init?.body));
+				return providerResponse({ request_id: REQUEST_ID }, 202);
+			}
+		);
 		assert.equal(response.status, 202);
 		const authorization = await response.json();
 		assert.equal(typeof authorization.agentBudget, 'string');
@@ -267,17 +270,26 @@ test('autonomous provider jobs require a signed shared budget and reject overspe
 		providerCalls++;
 		return providerResponse({ request_id: REQUEST_ID }, 202);
 	};
-	const missing = await editDrawingImage(await createEvent({ form: createForm(base) }), provider);
+	const missing = await editDrawingImage(
+		await createEvent({ owner: false, form: createForm(base) }),
+		provider
+	);
 	assert.equal(missing.status, 402);
 	const grant = await createDrawingAgentBudget(0.25, SESSION_SECRET);
 	const almostSpent = await chargeDrawingAgentBudget(grant, 0.2, SESSION_SECRET);
 	const exceeded = await editDrawingImage(
-		await createEvent({ form: createForm({ ...base, agentBudget: almostSpent.token }) }),
+		await createEvent({
+			owner: false,
+			form: createForm({ ...base, agentBudget: almostSpent.token })
+		}),
 		provider
 	);
 	assert.equal(exceeded.status, 402);
 	const tampered = await editDrawingImage(
-		await createEvent({ form: createForm({ ...base, agentBudget: `${grant}tampered` }) }),
+		await createEvent({
+			owner: false,
+			form: createForm({ ...base, agentBudget: `${grant}tampered` })
+		}),
 		provider
 	);
 	assert.equal(tampered.status, 402);
@@ -558,14 +570,14 @@ test('agent spending limits use parameter-adjusted provider prices before paid s
 		providerSafetyDefaults: '1',
 		agentBudget: await createDrawingAgentBudget(1, SESSION_SECRET)
 	});
-	const accepted = await editDrawingImage(await createEvent({ form }), async () => {
+	const accepted = await editDrawingImage(await createEvent({ owner: false, form }), async () => {
 		calls++;
 		return providerResponse({ request_id: REQUEST_ID }, 202);
 	});
 	assert.equal(accepted.status, 202);
 	assert.equal((await accepted.json()).spendingUsd, 0.8);
 	form.set('settings', JSON.stringify({ duration: '4s', generate_audio: true }));
-	const rejected = await editDrawingImage(await createEvent({ form }), async () => {
+	const rejected = await editDrawingImage(await createEvent({ owner: false, form }), async () => {
 		calls++;
 		return providerResponse({ request_id: REQUEST_ID }, 202);
 	});
@@ -948,7 +960,7 @@ test('media submission fails closed without a ledger or after durable funded quo
 	const ledger = createTestAiLedger();
 	for (let index = 0; index < 5; index++)
 		await ledgerRequest(ledger, 'admit', {
-			userId: 'owner-google-sub',
+			userId: 'other-google-sub',
 			kind: 'media',
 			model: 'flux-2',
 			estimatedReservedUsd: 0.05
@@ -957,10 +969,13 @@ test('media submission fails closed without a ledger or after durable funded quo
 		[null, 503],
 		[ledger, 429]
 	]) {
-		const response = await editDrawingImage(await createEvent({ ledger: value }), async () => {
-			called = true;
-			return providerResponse({ request_id: REQUEST_ID });
-		});
+		const response = await editDrawingImage(
+			await createEvent({ owner: false, ledger: value }),
+			async () => {
+				called = true;
+				return providerResponse({ request_id: REQUEST_ID });
+			}
+		);
 		assert.equal(response.status, expected);
 	}
 	assert.equal(called, false);
@@ -998,7 +1013,11 @@ test('manual concurrent generation reserves one run budget before provider submi
 	};
 	const events = await Promise.all(
 		Array.from({ length: 4 }, (_, index) =>
-			createEvent({ ledger, form: createForm({ ...base, clientJobId: `job-${index}` }) })
+			createEvent({
+				owner: false,
+				ledger,
+				form: createForm({ ...base, clientJobId: `job-${index}` })
+			})
 		)
 	);
 	const responses = await Promise.all(events.map((event) => editDrawingImage(event, provider)));
@@ -1006,7 +1025,11 @@ test('manual concurrent generation reserves one run budget before provider submi
 	assert.equal(responses.filter((response) => response.status === 402).length, 2);
 	assert.equal(calls, 2);
 	const duplicate = await editDrawingImage(
-		await createEvent({ ledger, form: createForm({ ...base, clientJobId: 'job-0' }) }),
+		await createEvent({
+			owner: false,
+			ledger,
+			form: createForm({ ...base, clientJobId: 'job-0' })
+		}),
 		provider
 	);
 	assert.equal(duplicate.status, 409);
@@ -1019,6 +1042,7 @@ test('manual concurrent generation reserves one run budget before provider submi
 	]) {
 		const response = await editDrawingImage(
 			await createEvent({
+				owner: false,
 				ledger,
 				form: createForm({ prompt: base.prompt, model: base.model, ...fields })
 			}),
@@ -1027,6 +1051,70 @@ test('manual concurrent generation reserves one run budget before provider submi
 		assert.equal(response.status, 422);
 	}
 	assert.equal(calls, 2);
+});
+
+test('owner media has no account or run cap, retains replay protection, and cannot grant that exemption to members', async () => {
+	const ledger = createTestAiLedger();
+	let calls = 0;
+	const provider = async () => providerResponse({ request_id: `owner-job-${++calls}` }, 202);
+	const fields = {
+		image: new File(['source'], 'source.png', { type: 'image/png' }),
+		prompt: 'Animate the scene',
+		model: 'veo-3-1-video',
+		runId: 'owner-run',
+		runLimitUsd: 'null',
+		providerSafetyDefaults: '1'
+	};
+	for (let index = 0; index < 8; index++) {
+		const response = await editDrawingImage(
+			await createEvent({
+				ledger,
+				form: createForm({ ...fields, clientJobId: `job-${index}` })
+			}),
+			provider
+		);
+		assert.equal(response.status, 202);
+		assert.equal((await response.json()).agentBudget, undefined);
+	}
+	const repeated = await editDrawingImage(
+		await createEvent({
+			ledger,
+			form: createForm({ ...fields, clientJobId: 'job-0' })
+		}),
+		provider
+	);
+	assert.equal(repeated.status, 409);
+	assert.equal((await repeated.json()).code, 'job_already_submitted');
+	const member = await editDrawingImage(
+		await createEvent({
+			owner: false,
+			ledger,
+			form: createForm({ ...fields, clientJobId: 'member-job' })
+		}),
+		provider
+	);
+	assert.equal(member.status, 422);
+	const impersonation = await editDrawingImage(
+		await createEvent({
+			owner: false,
+			ledger,
+			form: createForm({ ...fields, clientJobId: 'member-job', isOwner: 'true' })
+		}),
+		provider
+	);
+	assert.equal(impersonation.status, 400);
+	assert.equal(calls, 8);
+	const usage = ledger.database
+		.prepare(
+			"SELECT COUNT(*) AS count, SUM(reserved_micros) AS reserved FROM tools_ai_usage WHERE user_id = 'owner-google-sub'"
+		)
+		.get();
+	assert.equal(usage.count, 8);
+	assert.ok(usage.reserved > 2_000_000);
+	assert.equal(
+		ledger.database.prepare('SELECT limit_micros FROM tools_ai_generation_runs').get().limit_micros,
+		0
+	);
 });
 
 test('shared route authenticates and registers a fake adapter, then polls its original binding after catalog routing changes', async () => {

--- a/tests/draw-generation-batch.test.mjs
+++ b/tests/draw-generation-batch.test.mjs
@@ -30,6 +30,16 @@ test('run snapshots recipes and rejects an incompatible or over-budget batch bef
 	assert.throws(() => run([{ ...recipe(), modelId: 'nano-banana-2' }]), /Attach one/);
 });
 
+test('owner runs omit the client budget while preserving recipe validation', () => {
+	const batch = run(
+		Array.from({ length: 25 }, (_, index) => recipe(`recipe-${index}`)),
+		null
+	);
+	assert.equal(batch.limitUsd, null);
+	assert.equal(batch.jobs.length, 25);
+	assert.throws(() => run([{ ...recipe(), prompt: '' }], null), /Enter a prompt/);
+});
+
 test('comparison runs at bounded concurrency and keeps normalized results tied to recipes and run budget', async () => {
 	const batch = run([recipe('a'), recipe('b'), recipe('c')]);
 	let active = 0,

--- a/tests/draw-generation-provider.test.mjs
+++ b/tests/draw-generation-provider.test.mjs
@@ -150,3 +150,25 @@ test('run reservations retain limits and replay claims across helper reconstruct
 	assert.equal(runs.adapterFor('reservation-one'), 'fake');
 	assert.equal(runs.bindAdapter('alice', 'reservation-one', 'fal').status, 409);
 });
+
+test('owner runs bypass their previous cap but keep replay claims and fail closed after demotion', async () => {
+	const fixture = createTestAiLedger();
+	const runs = new GenerationRuns(fixture.sql);
+	const run = { id: 'owner-run', clientJobId: 'one', limitUsd: 0.2 };
+	runs.reserve(runs.prepare('owner', run, 125_000), 'one', Date.now());
+	const second = runs.prepare(
+		'owner',
+		{ ...run, clientJobId: 'two', limitUsd: null },
+		10_000_000,
+		true
+	);
+	assert.ok(!(second instanceof Response));
+	runs.reserve(second, 'two', Date.now());
+	assert.equal(second.limitMicros, 0);
+	assert.equal(second.reservedMicros, 10_125_000);
+	const replay = runs.prepare('owner', { ...run, clientJobId: 'two' }, 125_000, true);
+	assert.equal(replay.status, 409);
+	assert.equal((await replay.json()).code, 'job_already_submitted');
+	assert.equal(runs.prepare('owner', { ...run, clientJobId: 'three' }, 125_000).status, 409);
+	assert.equal(runs.prepare('member', { ...run, limitUsd: null }, 125_000).status, 422);
+});

--- a/tests/draw-image-tools.spec.js
+++ b/tests/draw-image-tools.spec.js
@@ -25,14 +25,14 @@ async function uploadedFalForm(request) {
 	};
 }
 
-/** @param {import('@playwright/test').Page} page */
-async function mockSignedInPersonalTools(page) {
+/** @param {import('@playwright/test').Page} page @param {boolean} [owner] */
+async function mockSignedInPersonalTools(page, owner = false) {
 	await page.route('**/tools/api/session', async (route) => {
 		if (route.request().method() === 'GET') {
 			await route.fulfill({
 				json: {
 					authenticated: true,
-					user: { ...TEST_TOOLS_OWNER, isOwner: true },
+					user: { ...(owner ? TEST_TOOLS_OWNER : TEST_TOOLS_MEMBER), isOwner: owner },
 					googleConfigured: true
 				}
 			});
@@ -1463,7 +1463,62 @@ test('the drawing AI action shares the Google owner session', async ({ page }) =
 
 	toolbox = await pasteSelectedImage(page);
 	await toolbox.getByRole('button', { name: 'AI prompt', exact: true }).click();
-	await expect(toolbox.getByText(/Funded by swyx.io/)).toBeVisible();
+	await expect(toolbox.getByText(/Funded by swyx.io/)).toHaveCount(0);
+	await expect(toolbox.getByRole('spinbutton', { name: 'Run spending limit' })).toHaveCount(0);
 	await expect(toolbox.getByRole('button', { name: 'Generate AI image edit' })).toBeVisible();
 	await expect(toolbox.getByRole('link', { name: 'Sign in to generate' })).toHaveCount(0);
+});
+
+test('owner generation exceeds the normal run cap without spending prompts and retains provider errors', async ({
+	page
+}) => {
+	await mockSignedInPersonalTools(page, true);
+	/** @type {Record<string,FormDataEntryValue>[]} */
+	const requests = [];
+	let confirmations = 0;
+	page.on('dialog', async (dialog) => {
+		confirmations++;
+		await dialog.dismiss();
+	});
+	await page.route('**/tools/api/draw/edit**', async (route) => {
+		if (route.request().method() !== 'POST') return route.continue();
+		const body = route.request().postDataBuffer();
+		const contentType = await route.request().headerValue('content-type');
+		if (!body || !contentType) throw new Error('A multipart request is required.');
+		const form = await new Response(new Uint8Array(body), {
+			headers: { 'Content-Type': contentType }
+		}).formData();
+		requests.push(Object.fromEntries(form));
+		await route.fulfill({ status: 503, json: { error: 'Fixture generation is unavailable.' } });
+	});
+	const toolbox = await pasteSelectedImage(page);
+	await toolbox.getByRole('button', { name: 'AI prompt', exact: true }).click();
+	await chooseOnlyModel(toolbox, 'veo-3-1-video');
+	const settings = toolbox.getByRole('region', { name: 'Image to video settings' });
+	await settings.getByLabel('Image to video Duration').selectOption('6');
+	await settings.getByLabel('Image to video Generate audio').uncheck();
+	await expect(toolbox.getByText('~$1.2 total · 1 generation')).toBeVisible();
+	await expect(toolbox.getByRole('spinbutton', { name: 'Run spending limit' })).toHaveCount(0);
+	await expect(
+		toolbox.getByRole('spinbutton', { name: 'Generation confirmation threshold' })
+	).toHaveCount(0);
+	await expect(toolbox.getByRole('complementary', { name: 'Funded AI usage notice' })).toHaveCount(
+		0
+	);
+	await expect(toolbox.getByText(/Uploads the reference to/)).toHaveCount(0);
+	await toolbox
+		.getByRole('textbox', { name: 'AI image editing prompt' })
+		.fill('Slow cinematic camera orbit');
+	const generate = toolbox.getByRole('button', { name: 'Generate AI video' });
+	await expect(generate).toBeEnabled();
+	await generate.click();
+	await expect(toolbox.getByRole('region', { name: 'Generation queue' })).toContainText(
+		'Fixture generation is unavailable.'
+	);
+	expect(confirmations).toBe(0);
+	expect(requests).toHaveLength(1);
+	expect(requests[0].runLimitUsd).toBe('null');
+	await expect(
+		toolbox.getByRole('button', { name: 'Retry failed jobs', exact: true })
+	).toBeVisible();
 });

--- a/tests/draw-pages.spec.js
+++ b/tests/draw-pages.spec.js
@@ -304,7 +304,7 @@ test('account switching keeps browser caches separate and removes owner-only too
 	);
 });
 
-test('all accounts see funded AI limits and logging before using the assistant', async ({
+test('members and guests see funded AI limits and logging before using the assistant', async ({
 	page
 }) => {
 	await page.goto('/tools');

--- a/tests/tools-ai-usage.test.mjs
+++ b/tests/tools-ai-usage.test.mjs
@@ -4,6 +4,8 @@ import { TOOLS_AI_POLICY, estimateToolsMediaReservation } from '../src/lib/tools
 import { ToolsAiUsage } from '../workers/draw/ai-usage.js';
 import drawWorker from '../workers/draw/index.js';
 import { createTestAiLedger, ledgerRequest, seedTestJob } from './helpers/tools-ai-ledger.mjs';
+import { createToolsSession } from '../src/lib/server/tools-auth.js';
+import { reserveToolsAiUsage, toolsAiLedger } from '../src/lib/server/tools-ai-usage.js';
 
 const HOUR = 3_600_000;
 const DAY = 24 * HOUR;
@@ -19,6 +21,79 @@ const media = (userId = 'alice', estimatedReservedUsd = 0.05) => ({
 	kind: 'media',
 	model: 'flux-2',
 	estimatedReservedUsd
+});
+
+test('only the configured owner bypasses budgets, remains logged, and cannot exhaust member funding', async () => {
+	const ledger = createTestAiLedger();
+	const secret = 'owner-exemption-test-secret-at-least-32-characters';
+	const eventFor = async (id) => {
+		const session = await createToolsSession(
+			{ id, email: 'owner@example.com', name: 'Test' },
+			secret
+		);
+		return {
+			platform: {
+				env: {
+					DRAW_PAGES: ledger.namespace,
+					TOOLS_SESSION_SECRET: secret,
+					TOOLS_OWNER_GOOGLE_SUB: 'owner'
+				}
+			},
+			cookies: { get: () => session }
+		};
+	};
+	const owner = await eventFor('owner');
+	for (let index = 0; index < 22; index++) {
+		const reservation = await reserveToolsAiUsage(owner, 'owner', 'assistant', 'model', 0.05);
+		assert.equal(typeof reservation.id, 'string');
+	}
+	for (let index = 0; index < 7; index++) {
+		const reservation = await reserveToolsAiUsage(owner, 'owner', 'media', 'model', 101);
+		assert.equal(typeof reservation.id, 'string');
+	}
+	const summary = await (await toolsAiLedger(owner, 'summary', { userId: 'owner' })).json();
+	assert.equal(summary.unlimited, true);
+	assert.equal(summary.policy.assistantTurnsPerHour, null);
+	assert.equal(summary.policy.mediaJobsPerHour, null);
+	assert.equal(summary.policy.userEstimatedDailyUsd, null);
+	assert.equal(summary.policy.siteEstimatedDailyUsd, null);
+	assert.equal(summary.usage.assistantTurnsThisHour, 22);
+	assert.equal(summary.usage.mediaJobsThisHour, 7);
+	assert.equal(summary.usage.estimatedReservedTodayUsd, 708.1);
+	assert.equal(summary.logging.retentionDays, 30);
+	// Same email and forged role/owner metadata cannot confer the exemption.
+	const member = await eventFor('member');
+	const memberSummary = await (
+		await toolsAiLedger(member, 'summary', {
+			userId: 'member',
+			ownerUserId: 'member',
+			isOwner: true
+		})
+	).json();
+	assert.equal(memberSummary.unlimited, false);
+	assert.equal(memberSummary.policy.userEstimatedDailyUsd, 2);
+	assert.equal((await reserveToolsAiUsage(member, 'owner', 'media', 'model', 1)).status, 409);
+	for (let index = 0; index < 10; index++) {
+		const userId = `member-${index}`;
+		const admitted = await reserveToolsAiUsage(await eventFor(userId), userId, 'media', 'model', 2);
+		assert.equal(typeof admitted.id, 'string');
+	}
+	const capped = await reserveToolsAiUsage(member, 'member', 'assistant', 'model', 0.05);
+	assert.equal(capped.status, 429);
+	assert.equal((await capped.json()).code, 'site_daily_limit');
+	assert.equal(
+		typeof (await reserveToolsAiUsage(owner, 'owner', 'media', 'model', 5)).id,
+		'string'
+	);
+	owner.platform.env.TOOLS_OWNER_GOOGLE_SUB = 'new-owner';
+	const demoted = await reserveToolsAiUsage(owner, 'owner', 'assistant', 'model', 0.05);
+	assert.equal(demoted.status, 429);
+	assert.equal(
+		ledger.database
+			.prepare('SELECT COUNT(*) AS count FROM tools_ai_usage WHERE user_id = ?')
+			.get('owner').count,
+		30
+	);
 });
 
 test('concurrent admission atomically enforces exactly 20 assistant turns and 5 media jobs per account/hour', async () => {

--- a/tests/tools-hub.spec.js
+++ b/tests/tools-hub.spec.js
@@ -207,6 +207,9 @@ for (const [name, width, height] of viewports) {
 		expect(panel.x).toBeGreaterThanOrEqual(0);
 		expect(panel.x + panel.width).toBeLessThanOrEqual(width);
 		await page.keyboard.press('Escape');
+		await expect(page.locator('.workshop-rules')).toHaveCount(0);
+		await authenticateTools(page, TEST_TOOLS_MEMBER);
+		await page.reload();
 		await page.getByText('The rules of the workshop', { exact: true }).click();
 		await expect(page.getByRole('complementary', { name: 'Funded AI usage notice' })).toBeVisible();
 		await expect(page.locator('.workshop-rules')).toContainText('$20 site-wide guard');
@@ -216,3 +219,28 @@ for (const [name, width, height] of viewports) {
 		);
 	});
 }
+
+test('owner usage is uncapped and quiet while member notices remain visible', async ({ page }) => {
+	await signIn(page);
+	const usage = page.getByRole('complementary', { name: 'Usage summary' });
+	await expect(usage).toContainText("Today's usage");
+	await expect(usage).toContainText('$0.05');
+	await expect(usage).not.toContainText('/ $2.00');
+	await expect(usage).not.toContainText(' / 20');
+	await expect(usage).not.toContainText(' / 5');
+	await expect(page.locator('.workshop-rules')).toHaveCount(0);
+	await expect(page.getByText('AI is funded by swyx.io, rate limited, and logged.')).toHaveCount(0);
+	await page.goto('/tools/box');
+	await expect(page.getByRole('textbox', { name: 'Write anything' })).toBeVisible();
+	await expect(page.locator('.logging-note')).toHaveCount(0);
+	await authenticateTools(page, TEST_TOOLS_MEMBER);
+	await page.reload();
+	await expect(page.locator('.logging-note')).toBeVisible();
+	await page.goto('/tools');
+	await expect(page.getByRole('complementary', { name: 'Usage allowance' })).toContainText(
+		'$0.05 / $2.00'
+	);
+	await expect(
+		page.getByText('AI is funded by swyx.io, rate limited, and logged.', { exact: true }).first()
+	).toBeVisible();
+});

--- a/workers/draw/ai-usage.js
+++ b/workers/draw/ai-usage.js
@@ -73,13 +73,18 @@ export class ToolsAiUsage {
 	/** All reads and writes below remain synchronous, with no interleaving before the reservation. @param {Record<string, any>} body @param {number} now */
 	admit(body, now) {
 		const { userId, kind, model, estimatedReservedUsd } = body;
+		const ownerUserId =
+			typeof body.ownerUserId === 'string' && IDENTIFIER.test(body.ownerUserId)
+				? body.ownerUserId
+				: '';
+		const unlimited = userId === ownerUserId;
 		if (
 			!['assistant', 'media'].includes(kind) ||
 			typeof model !== 'string' ||
 			!MODEL.test(model) ||
 			!Number.isFinite(estimatedReservedUsd) ||
 			estimatedReservedUsd <= 0 ||
-			estimatedReservedUsd > 100
+			(estimatedReservedUsd > 100 && !unlimited)
 		)
 			return Response.json({ error: 'Invalid usage reservation.' }, { status: 400 });
 		const micros = Math.ceil(estimatedReservedUsd * MILLION);
@@ -87,11 +92,11 @@ export class ToolsAiUsage {
 			kind === 'assistant'
 				? TOOLS_AI_POLICY.assistantReservationUsd
 				: TOOLS_AI_POLICY.mediaMinimumReservationUsd;
-		if (micros < Math.round(minimum * MILLION))
+		if (!Number.isSafeInteger(micros) || micros < Math.round(minimum * MILLION))
 			return Response.json({ error: 'Invalid usage reservation.' }, { status: 400 });
 		if (body.run !== undefined && kind !== 'media')
 			return Response.json({ error: 'Run budgets apply to media generation.' }, { status: 400 });
-		const run = this.generationRuns.prepare(userId, body.run, micros);
+		const run = this.generationRuns.prepare(userId, body.run, micros, unlimited);
 		if (run instanceof Response) return run;
 		const usage = this.summary(userId, now);
 		const limit =
@@ -102,18 +107,20 @@ export class ToolsAiUsage {
 		const dayStart = Math.floor(now / DAY_MS) * DAY_MS;
 		const total = this.sql
 			.exec(
-				'SELECT COALESCE(SUM(reserved_micros), 0) AS total FROM tools_ai_usage WHERE created_at >= ?',
-				dayStart
+				'SELECT COALESCE(SUM(reserved_micros), 0) AS total FROM tools_ai_usage WHERE created_at >= ? AND user_id != ?',
+				dayStart,
+				ownerUserId
 			)
 			.one().total;
 		let code;
-		if (used >= limit) code = 'account_hourly_limit';
+		if (!unlimited && used >= limit) code = 'account_hourly_limit';
 		else if (
+			!unlimited &&
 			Math.round(usage.estimatedReservedTodayUsd * MILLION) + micros >
-			TOOLS_AI_POLICY.userEstimatedDailyUsd * MILLION
+				TOOLS_AI_POLICY.userEstimatedDailyUsd * MILLION
 		)
 			code = 'account_daily_limit';
-		else if (total + micros > TOOLS_AI_POLICY.siteEstimatedDailyUsd * MILLION)
+		else if (!unlimited && total + micros > TOOLS_AI_POLICY.siteEstimatedDailyUsd * MILLION)
 			code = 'site_daily_limit';
 		if (code) {
 			const firstOfKind =
@@ -186,7 +193,18 @@ export class ToolsAiUsage {
 		if (path === '/ai/admit') return this.admit(body, now);
 		if (path === '/ai/summary')
 			return Response.json({
-				policy: TOOLS_AI_POLICY,
+				policy: {
+					...TOOLS_AI_POLICY,
+					...(body.userId === body.ownerUserId
+						? {
+								assistantTurnsPerHour: null,
+								mediaJobsPerHour: null,
+								userEstimatedDailyUsd: null,
+								siteEstimatedDailyUsd: null
+							}
+						: {})
+				},
+				unlimited: body.userId === body.ownerUserId,
 				usage: this.summary(body.userId, now),
 				logging: TOOLS_AI_LOGGING
 			});

--- a/workers/draw/generation-runs.js
+++ b/workers/draw/generation-runs.js
@@ -18,9 +18,9 @@ export class GenerationRuns {
 	}
 
 	/** Called synchronously with account/site admission, before any external I/O.
-	 * @param {string} userId @param {unknown} raw @param {number} micros
+	 * @param {string} userId @param {unknown} raw @param {number} micros @param {boolean} [unlimited]
 	 */
-	prepare(userId, raw, micros) {
+	prepare(userId, raw, micros, unlimited = false) {
 		if (raw === undefined) return undefined;
 		const run = /** @type {{id?: unknown, limitUsd?: unknown, clientJobId?: unknown} | null} */ (
 			raw
@@ -32,16 +32,20 @@ export class GenerationRuns {
 			!ID.test(run.id) ||
 			typeof run.clientJobId !== 'string' ||
 			!ID.test(run.clientJobId) ||
-			typeof run.limitUsd !== 'number' ||
-			!Number.isFinite(run.limitUsd) ||
-			run.limitUsd <= 0 ||
-			run.limitUsd > 100
+			(!unlimited &&
+				(typeof run.limitUsd !== 'number' ||
+					!Number.isFinite(run.limitUsd) ||
+					run.limitUsd <= 0 ||
+					run.limitUsd > 100))
 		)
 			return Response.json(
 				{ code: 'invalid_run_budget', error: 'Choose a valid run spending limit.' },
 				{ status: 422 }
 			);
-		const limitMicros = Math.floor(run.limitUsd * MILLION + 1e-7);
+		// Zero records an owner-exempt run; only server-authorized owners can use it.
+		const limitMicros = unlimited
+			? 0
+			: Math.floor(/** @type {number} */ (run.limitUsd) * MILLION + 1e-7);
 		const existing = this.sql
 			.exec(
 				'SELECT limit_micros, reserved_micros FROM tools_ai_generation_runs WHERE user_id = ? AND run_id = ?',
@@ -49,7 +53,7 @@ export class GenerationRuns {
 				run.id
 			)
 			.toArray()[0];
-		if (existing && existing.limit_micros !== limitMicros)
+		if (!unlimited && existing && existing.limit_micros !== limitMicros)
 			return Response.json(
 				{
 					code: 'run_budget_changed',
@@ -75,7 +79,7 @@ export class GenerationRuns {
 				{ status: 409 }
 			);
 		const reservedMicros = (existing?.reserved_micros ?? 0) + micros;
-		if (reservedMicros > limitMicros)
+		if (!unlimited && reservedMicros > limitMicros)
 			return Response.json(
 				{
 					code: 'run_budget_exceeded',
@@ -95,7 +99,7 @@ export class GenerationRuns {
 	reserve(run, usageId, now) {
 		this.sql.exec(
 			`INSERT INTO tools_ai_generation_runs (user_id, run_id, limit_micros, reserved_micros, updated_at)
-			VALUES (?, ?, ?, ?, ?) ON CONFLICT (user_id, run_id) DO UPDATE SET reserved_micros = excluded.reserved_micros, updated_at = excluded.updated_at`,
+			VALUES (?, ?, ?, ?, ?) ON CONFLICT (user_id, run_id) DO UPDATE SET limit_micros = excluded.limit_micros, reserved_micros = excluded.reserved_micros, updated_at = excluded.updated_at`,
 			run.userId,
 			run.runId,
 			run.limitMicros,


### PR DESCRIPTION
## Changes
- Exempt the configured Google owner from hourly account limits, daily account/site budgets, assistant spending caps, and generation-run caps.
- Keep owner usage fully metadata-logged; exclude owner spending from the shared non-owner allowance.
- Derive the exemption from server configuration and authenticated Google subject, never email or browser flags.
- Hide owner funding/logging/provider-sharing notices and spending confirmations. Keep usage counts and estimates, actual errors, data-loss warnings, replay protection, and provider safety settings.
- Preserve all member limits and disclosures.

## Verification
- 466 unit tests passed, including same-email impersonation, forged owner metadata, owner demotion, logged over-limit owner usage, preserved shared allowance, and run replay prevention.
- 119 browser tests passed; 4 explicit live-provider tests skipped (no paid inference).
- Typecheck: 0 errors, 0 warnings. Production build passed.
- Rebased on source-first Draw release b390444; existing creative schema and private namespace preserved.

## Rollout
Deploy the Draw companion first, preserving its existing namespace and variables, then merge this PR for the main Worker build. No secrets, provider limits, storage schema, or account roles are changed. Owner exemption requires the new main Worker, so the companion-first transition leaves current limits intact until activation.
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/swyxio/swyxdotio/pull/568?analyze=true)

<a href="https://staging.itsdev.in/review/swyxio/swyxdotio/pull/568" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-staging-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-staging-light.svg?v=3" alt="Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/swyxio/swyxdotio/pull/568" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->