### PR TITLE
Enable isolated tools sign-in during loopback Vite development

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,6 +434,23 @@ See https://swyx.io
 
 ## Google sign-in and tenant boundaries
 
+### Local development
+
+`npm run dev` automatically provides a **Local developer** tools account on HTTP
+`localhost`, `127.0.0.1`, and `[::1]`. No Google setup or cookie injection is needed.
+The synthetic `local-development` identity is a regular member with its own
+cache/storage namespace, not the production owner or your Google data. Existing
+valid sessions take precedence. To test the real signed-out/Google flow, restart
+with `TOOLS_DEV_AUTH=off npm run dev`.
+
+This requires Vite's build-time `DEV` flag **and** a loopback URL. It is unavailable
+in production builds, deployed previews, LAN hosts, or `wrangler dev` running a
+production build; those previews use normal Google/test-fixture sessions.
+Local sign-in does not supply storage bindings or provider keys, and no AI request
+starts automatically. Vite keeps remote bindings disabled.
+
+### Production sessions
+
 Tools follow [Google OpenID Connect](https://developers.google.com/identity/openid-connect/openid-connect) through [`openid-client`](https://github.com/panva/openid-client) with PKCE, state, nonce,
 issuer/audience/expiry checks and signed ID-token verification. `jose` signs the
 seven-day HTTP-only tools session. No Google access/refresh tokens are retained.

--- a/src/lib/podcast-admin-route.js
+++ b/src/lib/podcast-admin-route.js
@@ -21,7 +21,7 @@ export function requireSameOrigin(request, url) {
  * @returns {Promise<R2Bucket | undefined>}
  */
 export async function requirePodcastStudio({ cookies, platform, request, url }) {
-	const user = await getToolsUser({ cookies, platform });
+	const user = await getToolsUser({ cookies, platform, url });
 	if (!user) throw error(401, 'Sign in with Google');
 	if (!user.isOwner) throw error(403, 'Podcast publishing is available only to the site owner.');
 	const expectedUser = request.headers.get('X-Tools-User');

--- a/src/lib/server/tools-auth.js
+++ b/src/lib/server/tools-auth.js
@@ -7,8 +7,24 @@ const SESSION_AUDIENCE = 'tools-session';
 const CALLBACK_PATH = '/tools/auth/google/callback';
 
 /** @typedef {{ id: string, email: string, name: string }} ToolsIdentity */
-/** @typedef {ToolsIdentity & { isOwner: boolean }} ToolsUser */
-/** @typedef {Pick<import('@sveltejs/kit').RequestEvent, 'cookies' | 'platform'>} ToolsSessionEvent */
+/** @typedef {ToolsIdentity & { isOwner: boolean, isDevelopment?: boolean }} ToolsUser */
+/** @typedef {Pick<import('@sveltejs/kit').RequestEvent, 'cookies' | 'platform'> & Partial<Pick<import('@sveltejs/kit').RequestEvent, 'url'>>} ToolsSessionEvent */
+
+/** A synthetic member, never the production owner's `personal` namespace.
+ * Called only inside the Vite DEV branch below; localhost alone is not authorization.
+ * @param {URL | undefined} url @returns {ToolsUser | null}
+ */
+export function localDevelopmentToolsUser(url) {
+	if (url?.protocol !== 'http:' || !['localhost', '127.0.0.1', '[::1]'].includes(url.hostname))
+		return null;
+	return {
+		id: 'local-development',
+		email: 'developer@localhost',
+		name: 'Local developer',
+		isOwner: false,
+		isDevelopment: true
+	};
+}
 
 /** @param {unknown} secret */
 export function validToolsSessionSecret(secret) {
@@ -80,7 +96,12 @@ export async function getToolsUser(event) {
 		event.cookies.get(toolsSessionCookieName()),
 		event.platform?.env?.TOOLS_SESSION_SECRET
 	);
-	if (!user) return null;
+	if (!user) {
+		// Production replaces DEV with false. Request headers and Worker vars cannot enable it.
+		if (import.meta.env?.DEV === true && process.env.TOOLS_DEV_AUTH !== 'off')
+			return localDevelopmentToolsUser(event.url);
+		return null;
+	}
 	const owner = event.platform?.env?.TOOLS_OWNER_GOOGLE_SUB;
 	return { ...user, isOwner: Boolean(owner && user.id === owner) };
 }

--- a/src/routes/tools/+page.svelte
+++ b/src/routes/tools/+page.svelte
@@ -82,32 +82,52 @@
 			<details class="account-menu" bind:this={accountMenu} on:focusout={closeAccountOutside}>
 				<summary
 					><span class="account-name">{data.user.name || data.user.email}</span><span
-						class="account-role">{data.user.isOwner ? 'Site owner' : 'Personal account'}</span
+						class="account-role"
+						>{data.user.isDevelopment
+							? 'Local development'
+							: data.user.isOwner
+								? 'Site owner'
+								: 'Personal account'}</span
 					><span class="chevron" aria-hidden="true">⌄</span></summary
 				>
 				<div class="account-panel">
 					<strong>{data.user.name || data.user.email}</strong>
 					<p>{data.user.email}</p>
 					<p class="sync-note">
-						Your drawings sync to your Google account’s workspace. Other accounts have their own.
+						{#if data.user.isDevelopment}
+							Synthetic local account. Uses a separate workspace, not your Google account's data.
+						{:else}
+							Your drawings sync to your Google account’s workspace. Other accounts have their own.
+						{/if}
 					</p>
 					<details class="account-identity">
 						<summary>Account identity</summary>
-						<p>Google account ID: <code>{data.user.id}</code></p>
+						<p>
+							{data.user.isDevelopment ? 'Development' : 'Google account'} ID:
+							<code>{data.user.id}</code>
+						</p>
 						<p>
 							{data.user.isOwner ? 'Site owner' : 'Personal account'} · permissions are checked on the
 							server.
 						</p>
 					</details>
-					<button class="plain-button signout" on:click={logout} disabled={signingOut}
-						>{signingOut ? 'Signing out…' : 'Sign out'}</button
-					>
+					{#if data.user.isDevelopment}
+						<p>To test sign-in, restart with <code>TOOLS_DEV_AUTH=off npm run dev</code>.</p>
+					{:else}<button class="plain-button signout" on:click={logout} disabled={signingOut}
+							>{signingOut ? 'Signing out…' : 'Sign out'}</button
+						>{/if}
 				</div>
 			</details>
 		{/if}
 	</div>
 	{#if data.authError}<p class="error" role="alert">{data.authError}</p>{/if}
 	{#if error}<p class="error" role="alert">{error}</p>{/if}
+	{#if data.user?.isDevelopment}
+		<p class="sync-note" role="status">
+			Local development account active. No Google login needed. Storage bindings and AI providers
+			still need local configuration.
+		</p>
+	{/if}
 	<div class="workshop-intro">
 		<div class="intro-copy">
 			<h1>The useful things cabinet.</h1>

--- a/tests/tools-auth.test.mjs
+++ b/tests/tools-auth.test.mjs
@@ -5,6 +5,7 @@ import {
 	createToolsSession,
 	getToolsSession,
 	getToolsUser,
+	localDevelopmentToolsUser,
 	googleAuthConfig,
 	readToolsSession,
 	safeToolsNext,
@@ -158,6 +159,48 @@ test('roles use the current configured Google subject, never email, name, or sig
 		user: null,
 		googleConfigured: false
 	});
+});
+
+test('local development identity is loopback-only and never an owner or a Google identity', () => {
+	for (const host of ['localhost', '127.0.0.1', '[::1]']) {
+		assert.deepEqual(localDevelopmentToolsUser(new URL(`http://${host}:5193/tools/draw`)), {
+			id: 'local-development',
+			email: 'developer@localhost',
+			name: 'Local developer',
+			isOwner: false,
+			isDevelopment: true
+		});
+	}
+	for (const value of [
+		undefined,
+		'https://swyx.io/tools',
+		'http://localhost.evil.example/tools',
+		'http://192.168.1.2/tools',
+		'https://preview.workers.dev/tools',
+		'https://localhost/tools'
+	])
+		assert.equal(localDevelopmentToolsUser(value ? new URL(value) : undefined), null);
+});
+
+test('normal runtime never accepts a dev identity from localhost, flags or forwarded headers', async () => {
+	const event = createEvent('http://localhost:5193/tools', { TOOLS_DEV_AUTH: 'on' });
+	const previous = process.env.TOOLS_DEV_AUTH;
+	process.env.TOOLS_DEV_AUTH = 'on';
+	try {
+		event.request = new Request(event.url, {
+			headers: { 'X-Tools-User': 'local-development', 'X-Forwarded-Host': 'localhost:5193' }
+		});
+		assert.equal(await getToolsUser(event), null, 'Vite development mode is required');
+		event.values.set(toolsSessionCookieName(), await createToolsSession(IDENTITY, SECRET));
+		assert.equal(
+			(await getToolsUser(event)).id,
+			IDENTITY.id,
+			'real sessions retain their identity'
+		);
+	} finally {
+		if (previous === undefined) delete process.env.TOOLS_DEV_AUTH;
+		else process.env.TOOLS_DEV_AUTH = previous;
+	}
 });
 
 test('Google configuration and return targets fail closed, while alternate hosts redirect to the registered host', async () => {


### PR DESCRIPTION
## What changed

`npm run dev` now supplies a clearly labeled Local developer account on HTTP localhost, 127.0.0.1, and IPv6 loopback so Draw can be tested without Google login. It is a separate regular-member namespace, never the production owner or a Google identity. Valid signed sessions remain authoritative. `TOOLS_DEV_AUTH=off npm run dev` restores the real login flow.

The bypass requires Vite's build-time DEV flag and an exact loopback URL. Production builds remove it. No keys, remote bindings, owner exemption, member limits, companion Worker, or model configuration changed; no inference calls made.

## Verification

- Integrated master dc201d8, preserving PR572 artwork and PR573 social photos.
- 311 tools/drawing/about units passed; svelte-check 0 errors and warnings; production build passed.
- Vite5193 session endpoint and Chrome: Local developer signed in, Continue to Draw and assistant controls accessible.
- Vite opt-out process returns unauthenticated; non-loopback Host with forged forwarding headers returns unauthenticated. Unit coverage rejects HTTPS and non-loopback URLs.
- Compiled production Worker on localhost with TOOLS_DEV_AUTH=on: no cookie, fake identity, forwarding headers, and explicit localhost Host all remain unauthenticated; Draw pages API returns401. Fixture-signed owner and member sessions preserve real identity and role.
- Rebuilt combined production output: synthetic identity/helper absent from all197 generated JavaScript files.

## Rollout

Main app only. Existing Vite local proxy configuration remains remoteBindings:false; this sign-in does not supply storage bindings or provider keys. No automatic AI requests. No companion deployment required.
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/swyxio/swyxdotio/pull/574?analyze=true)

<a href="https://staging.itsdev.in/review/swyxio/swyxdotio/pull/574" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-staging-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-staging-light.svg?v=3" alt="Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/swyxio/swyxdotio/pull/574" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->