### PR TITLE
Clarify shared Google consent and swyxcal Calendar data use

### DIFF
--- a/src/routes/tools/+page.svelte
+++ b/src/routes/tools/+page.svelte
@@ -186,6 +186,12 @@
 		</div>
 	{/if}
 	<div class="workshop-scene"><ToolsCabinet isOwner={!!data.user?.isOwner} /></div>
+	<p class="calendar-disclosure">
+		The separately hosted <a href="https://cal.swyx.io/about">swyxcal</a> scheduler uses this Google
+		app’s consent configuration. Its invited team connects Google calendars in a separate flow;
+		ordinary Tools sign-in does not grant calendar access. Scheduler setup is in progress and new
+		bookings are paused. <a href="/tools/privacy#swyxcal">Calendar access and privacy →</a>
+	</p>
 	{#if !data.user?.isOwner}<details class="workshop-rules">
 			<summary
 				><span>The rules of the workshop</span><span class="rules-hint"
@@ -204,6 +210,17 @@
 </section>
 
 <style>
+	.calendar-disclosure {
+		max-width: 52rem;
+		margin: 1.5rem auto;
+		font-size: 0.8rem;
+		line-height: 1.7;
+		color: var(--page-muted);
+	}
+	.calendar-disclosure a {
+		text-decoration: underline;
+		text-underline-offset: 3px;
+	}
 	.tools {
 		--site-max-width: 1160px;
 		padding-block: 1.2rem 0.5rem;

--- a/src/routes/tools/privacy/+page.svelte
+++ b/src/routes/tools/privacy/+page.svelte
@@ -9,10 +9,11 @@
 	<p><a href="/tools">← Your tools</a></p>
 	<h1>Tools privacy</h1>
 	<p>
-		Google sign-in identifies your workspace using your Google account ID. We receive your basic
-		profile and verified email address, and keep a signed, HTTP-only sign-in cookie for up to seven
-		days. We do not request access to Gmail, Drive, contacts, or your Google password. Google access
-		tokens are not retained after sign-in.
+		Ordinary Tools/Draw Google sign-in identifies your workspace using your Google account ID. We
+		receive your basic profile and verified email address, and keep a signed, HTTP-only sign-in
+		cookie for up to seven days. We do not request access to Gmail, Drive, contacts, or your Google
+		password. For this Tools/Draw login flow, Google access tokens are not retained after sign-in.
+		This does not describe the separately authorized swyxcal calendar connections below.
 	</p>
 	<p>
 		Signed-in drawings are stored on Cloudflare in an account-specific workspace. Drawing caches,
@@ -69,4 +70,49 @@
 			href="/about">contact swyx</a
 		>.
 	</p>
+	<section id="swyxcal" aria-labelledby="swyxcal-heading">
+		<h2 id="swyxcal-heading">swyxcal: separately authorized Google Calendar access</h2>
+		<p>
+			The separately hosted <a href="https://cal.swyx.io/about">swyxcal</a> scheduler shares this Google
+			app’s consent configuration but has its own private, exact-email allowlisted team and storage. Ordinary
+			Tools sign-in does not connect calendars. In swyxcal, a member first signs in, then separately authorizes
+			a Google calendar account for ongoing scheduling access. Setup is in progress and new bookings are
+			paused; this disclosure is not a booking launch or a claim of Google verification.
+		</p>
+		<p>
+			Calendar linking requests <code>calendar.calendarlist.readonly</code> to list calendar
+			choices,
+			<code>calendar.events.freebusy</code> to check busy time on selected calendars,
+			<code>calendar.events.owned</code> to create and manage bookings on the organizer’s owned
+			destination, and <code>calendar.events.readonly</code> to check event metadata across selected conflict
+			calendars when rescheduling. Missing coverage is unavailable, not free. Public visitors see offered
+			times, not private calendar events. An older authorization may retain broader Google permissions
+			until separately revoked; updating the app does not revoke it.
+		</p>
+		<p>
+			swyxcal stores encrypted calendar refresh tokens for continued access, with short-lived access
+			tokens in server memory. It keeps account/calendar selections, availability, guest name, email
+			and time zone, booking and recovery records, and notification status in Cloudflare
+			Workers/Durable Object storage. Configured backups are encrypted in private Cloudflare R2.
+			These booking records do not use the Tools activity logs’ 30-day expiry.
+		</p>
+		<p>
+			Google processes calendar reads, booking writes, Meet and attendee invitations. Configured
+			Cloudflare email sends booking details and a private management link to the guest; hosts’
+			Google invitations do not include that private link. Cloudflare also processes hosting and
+			security checks. Read the <a href="https://cal.swyx.io/privacy">swyxcal privacy policy</a> for optional
+			agent access, data processing, retention and deletion requests, and the distinction between disconnecting
+			a live account and revoking Google access. Disconnecting does not automatically erase booking history
+			or backups.
+		</p>
+		<p>
+			swyxcal’s use and transfer of Google user data is limited to the scheduling functionality
+			described in its policy and the <a
+				href="https://developers.google.com/terms/api-services-user-data-policy"
+				>Google API Services User Data Policy</a
+			>, including Limited Use. Calendar data is not used for the separately described funded AI
+			features above, advertising, or training general-purpose AI models. For calendar-data
+			questions or requests, contact <a href="mailto:swyx@ai.engineer">swyx@ai.engineer</a>.
+		</p>
+	</section>
 </article>

--- a/tests/tools-hub.spec.js
+++ b/tests/tools-hub.spec.js
@@ -69,6 +69,43 @@ test('guest has three working direct links, honest disclosure, and a safe Google
 	await expect(page.getByRole('textbox', { name: 'Write anything' })).toBeVisible();
 });
 
+test('public calendar disclosures distinguish Tools login and preserve existing privacy details', async ({
+	page
+}) => {
+	await page.goto('/tools');
+	const disclosure = page.locator('.calendar-disclosure');
+	await expect(disclosure).toContainText('ordinary Tools sign-in does not grant calendar access');
+	await expect(disclosure).toContainText('new bookings are paused');
+	await expect(page.getByRole('navigation', { name: 'Your tools' }).getByRole('link')).toHaveCount(
+		3
+	);
+	await disclosure.getByRole('link', { name: 'Calendar access and privacy' }).click();
+	await expect(page).toHaveURL(/\/tools\/privacy#swyxcal$/);
+	const calendarPolicy = page.getByRole('region', {
+		name: 'swyxcal: separately authorized Google Calendar access'
+	});
+	for (const scope of [
+		'calendar.calendarlist.readonly',
+		'calendar.events.freebusy',
+		'calendar.events.owned',
+		'calendar.events.readonly'
+	]) {
+		await expect(calendarPolicy.locator('code').filter({ hasText: scope })).toBeVisible();
+	}
+	await expect(calendarPolicy).toContainText('encrypted calendar refresh tokens');
+	await expect(calendarPolicy).toContainText('do not use the Tools activity logs’ 30-day expiry');
+	await expect(
+		calendarPolicy.getByRole('link', { name: 'swyxcal privacy policy' })
+	).toHaveAttribute('href', 'https://cal.swyx.io/privacy');
+	await expect(page.locator('article')).toContainText(
+		'For this Tools/Draw login flow, Google access tokens are not retained after sign-in.'
+	);
+	await expect(page.getByRole('heading', { name: 'Funded AI: limits and logging' })).toBeVisible();
+	await expect(page.locator('article')).toContainText(
+		'Signing out removes the sign-in cookie; it does not delete saved drawings or device caches.'
+	);
+});
+
 test('account disclosure retains identity, dismisses conventionally, and adapts to role changes', async ({
 	page
 }) => {


### PR DESCRIPTION
## What changed

- Explain that swyxcal shares the Google consent configuration but uses separate invited-team Calendar linking; ordinary Tools sign-in grants no Calendar access.
- Add the four Calendar scopes, encrypted refresh-token and booking storage, Google invitations, Cloudflare/R2/email processing, and the detailed swyxcal privacy link.
- Limit the existing no-retained-Google-token statement to Tools/Draw login. Preserve other disclosures, Google clients/branding and cabinet entries. New scheduler bookings remain paused.

## Verification

- 485 Node tests passed on the final tree.
- Svelte check: 0 errors, 0 warnings.
- 12 Tools hub Chromium tests passed, including public privacy and responsive coverage.
- Production build passed.

Rebased on master e3a6d25 (diagram-kit release); tested head 3772525. Only two public Svelte pages and the existing Tools hub browser test changed. Merge is coordinated with the central main-Worker release owner, followed by the normal automatic production build. No companion Worker, OAuth configuration or runtime-permission changes.
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/swyxio/swyxdotio/pull/577?analyze=true)

<a href="https://staging.itsdev.in/review/swyxio/swyxdotio/pull/577" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-staging-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-staging-light.svg?v=3" alt="Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/swyxio/swyxdotio/pull/577" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->