### PR TITLE
Remove obsolete /now redirect after live route verification

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -21,7 +21,6 @@
 /writing/prerecording_talks /prerecording-talks 301
 /prerecording_talks /prerecording-talks 301
 /create_luck /create-luck 301
-/now /about#now 301
 
 
 /talks /ideas?show=Talk 301

--- a/docs/design/about-personas-2026-08-26/accepted-letter.md
+++ b/docs/design/about-personas-2026-08-26/accepted-letter.md
@@ -61,6 +61,8 @@ Limits: full keyboard-only traversal, 200% zoom, no-JavaScript browser mode, and
 
 Release checkout: `/Users/swyx/.codex/worktrees/swyxdotio-seo-aeo`, branch `codex/swyxdotio-seo-aeo`, targeting the repository's default `master`. Local verification does not imply production activation; release and live checks follow separately.
 
+After integrating current master: 527 tests passed, typecheck remained clean, and the production build succeeded. PR #580 deployed successfully. Live verification then caught a legacy root `_redirects` rule sending `/now` to `/about#now`, which the Vite preview did not apply. Removed that obsolete rule and added a regression assertion; direct production-route checks are required, not only client-side navigation.
+
 ## Memory ledger candidates
 
 Before implementing a two-pane design, identify each pane's semantic role: primary content, navigation, or commentary. Check that every substantive section remains in the intended reading column, rather than accepting a superficially similar two-column layout.

--- a/tests/about-letter.test.mjs
+++ b/tests/about-letter.test.mjs
@@ -77,5 +77,6 @@ test('/now is a dated standalone public page with a clearly historical update', 
 	assert.match(html, /not taking new advising inquiries/);
 	assert.ok(PUBLIC_PAGE_PATHS.includes('/now'));
 	assert.equal(getPageSocialMeta('now').canonical, 'https://swyx.io/now');
+	assert.doesNotMatch(await read('_redirects'), /^\/now\s/m);
 	assert.doesNotMatch(content, /\/tools|tools\.aieconf/);
 });


### PR DESCRIPTION
Live verification of #580 caught the legacy root _redirects entry still redirecting /now to /about#now. Remove it so the new standalone route can serve directly. Adds a regression assertion and records the production-only finding in the design handoff.

Focused About and discovery tests pass. The new page and OG route were already built and deployed in #580; this corrects the asset-layer redirect missed by Vite preview.
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/swyxio/swyxdotio/pull/581?analyze=true)

<a href="https://staging.itsdev.in/review/swyxio/swyxdotio/pull/581" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-staging-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-staging-light.svg?v=3" alt="Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/swyxio/swyxdotio/pull/581" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->