### PR TITLE
Show daily AI counts in Today's usage

### DIFF
--- a/src/lib/ToolsUsageReceipt.svelte
+++ b/src/lib/ToolsUsageReceipt.svelte
@@ -2,13 +2,15 @@
 	import { TOOLS_AI_POLICY } from '$lib/tools-ai-policy.js';
 	export let signedIn = false;
 	export let isOwner = false;
-	/** @type {{assistantTurnsThisHour:number,mediaJobsThisHour:number,estimatedReservedTodayUsd:number}|null} */
+	/** @type {{assistantTurnsToday:number,mediaJobsToday:number,estimatedReservedTodayUsd:number}|null} */
 	export let usage = null;
 	export let unavailable = false;
 </script>
 
 <aside class="receipt" aria-label={isOwner ? 'Usage summary' : 'Usage allowance'}>
-	<p class="receipt-title">{isOwner ? "Today's usage" : "Today's allowance"}</p>
+	<p class="receipt-title">
+		{signedIn ? "Today's usage" : "Today's allowance"}<span class="day-zone">UTC</span>
+	</p>
 	{#if signedIn}
 		<section
 			class="counters"
@@ -17,17 +19,8 @@
 			aria-busy={!usage && !unavailable}
 		>
 			{#if usage}
-				<p>
-					<b
-						>{usage.assistantTurnsThisHour}{isOwner
-							? ''
-							: ` / ${TOOLS_AI_POLICY.assistantTurnsPerHour}`}</b
-					><span>assistant turns this hour</span>
-				</p>
-				<p>
-					<b>{usage.mediaJobsThisHour}{isOwner ? '' : ` / ${TOOLS_AI_POLICY.mediaJobsPerHour}`}</b
-					><span>generations this hour</span>
-				</p>
+				<p><b>{usage.assistantTurnsToday}</b><span>assistant turns today</span></p>
+				<p><b>{usage.mediaJobsToday}</b><span>generations today</span></p>
 				<p>
 					<b
 						>${usage.estimatedReservedTodayUsd.toFixed(2)}{isOwner
@@ -109,6 +102,12 @@
 		background: #bb9a57;
 		border: 2px ridge #d6b77a;
 		box-shadow: 0 2px 2px #34281944;
+	}
+	.day-zone {
+		float: right;
+		color: #65513e;
+		font-size: 0.65rem;
+		font-weight: 400;
 	}
 	.receipt-title {
 		font: 600 0.83rem var(--font-mono);

--- a/src/routes/tools/+page.svelte
+++ b/src/routes/tools/+page.svelte
@@ -25,7 +25,7 @@
 			accountMenu.open = false;
 	}
 	let error = '';
-	/** @type {{assistantTurnsThisHour:number,mediaJobsThisHour:number,estimatedReservedTodayUsd:number}|null} */
+	/** @type {{assistantTurnsToday:number,mediaJobsToday:number,estimatedReservedTodayUsd:number}|null} */
 	let aiUsage = null;
 	let usageUnavailable = false;
 	onMount(() => {

--- a/tests/tools-ai-usage.test.mjs
+++ b/tests/tools-ai-usage.test.mjs
@@ -139,6 +139,8 @@ test('sliding hourly counters recover after one hour without resetting daily res
 	assert.equal(ledger.handle('/ai/admit', assistant(), NOW + HOUR).status, 201);
 	const summary = await ledger.handle('/ai/summary', { userId: 'alice' }, NOW + HOUR).json();
 	assert.equal(summary.usage.assistantTurnsThisHour, 1);
+	assert.equal(summary.usage.assistantTurnsToday, 21);
+	assert.equal(summary.usage.mediaJobsToday, 0);
 	assert.equal(summary.usage.estimatedReservedTodayUsd, 1.05);
 });
 
@@ -430,4 +432,26 @@ test('a job transport stays bound to its original adapter and run metadata expir
 	await fixture.object.alarm();
 	for (const table of ['tools_ai_usage', 'tools_ai_generation_runs', 'tools_ai_generation_jobs'])
 		assert.equal(fixture.database.prepare(`SELECT COUNT(*) AS count FROM ${table}`).get().count, 0);
+});
+
+test('daily usage shares the UTC spending boundary, counts failed admissions and isolates accounts', async () => {
+	const ledger = new ToolsAiUsage(createTestAiLedger().sql);
+	const midnight = Math.floor(NOW / DAY) * DAY;
+	ledger.handle('/ai/admit', assistant(), midnight - 1);
+	ledger.handle('/ai/admit', assistant(), midnight);
+	const failed = await ledger.handle('/ai/admit', media(), NOW - 2 * HOUR).json();
+	ledger.handle('/ai/finish', { userId: 'alice', id: failed.id, status: 'failed' }, NOW - HOUR);
+	ledger.handle('/ai/admit', media(), NOW);
+	ledger.handle('/ai/admit', assistant('bob'), NOW);
+	const usage = ledger.summary('alice', NOW);
+	assert.equal(usage.assistantTurnsToday, 1);
+	assert.equal(usage.mediaJobsToday, 2);
+	assert.equal(usage.assistantTurnsThisHour, 0);
+	assert.equal(usage.mediaJobsThisHour, 1);
+	assert.equal(usage.estimatedReservedTodayUsd, 0.15);
+	assert.equal(usage.dayResetsAt, new Date(midnight + DAY).toISOString());
+	const nextDay = ledger.summary('alice', midnight + DAY);
+	assert.equal(nextDay.assistantTurnsToday, 0);
+	assert.equal(nextDay.mediaJobsToday, 0);
+	assert.equal(nextDay.estimatedReservedTodayUsd, 0);
 });

--- a/tests/tools-hub.spec.js
+++ b/tests/tools-hub.spec.js
@@ -4,6 +4,8 @@ import { authenticateTools, TEST_TOOLS_OWNER, TEST_TOOLS_MEMBER } from './helper
 const sampleUsage = {
 	assistantTurnsThisHour: 1,
 	mediaJobsThisHour: 0,
+	assistantTurnsToday: 8,
+	mediaJobsToday: 3,
 	estimatedReservedTodayUsd: 0.05
 };
 
@@ -190,6 +192,8 @@ test('usage loading and failure never masquerade as zero, and browser reload rec
 	);
 	await page.reload();
 	await expect(usage).toContainText('$0.05 / $2.00');
+	await expect(usage).toContainText('assistant turns today');
+	await expect(usage).not.toContainText(' / 20');
 });
 
 test('signout shows pending and recoverable failure without hiding the current account', async ({
@@ -286,6 +290,10 @@ test('owner usage is uncapped and quiet while member notices remain visible', as
 	await signIn(page);
 	const usage = page.getByRole('complementary', { name: 'Usage summary' });
 	await expect(usage).toContainText("Today's usage");
+	await expect(usage).toContainText('UTC');
+	await expect(usage.locator('.counters p').nth(0)).toHaveText('8assistant turns today');
+	await expect(usage.locator('.counters p').nth(1)).toHaveText('3generations today');
+	await expect(usage).not.toContainText('this hour');
 	await expect(usage).toContainText('$0.05');
 	await expect(usage).not.toContainText('/ $2.00');
 	await expect(usage).not.toContainText(' / 20');

--- a/workers/draw/ai-usage.js
+++ b/workers/draw/ai-usage.js
@@ -61,17 +61,22 @@ export class ToolsAiUsage {
 			)
 			.one();
 		const dayStart = Math.floor(now / DAY_MS) * DAY_MS;
-		const spent = this.sql
+		const day = this.sql
 			.exec(
-				'SELECT COALESCE(SUM(reserved_micros), 0) AS total FROM tools_ai_usage WHERE user_id = ? AND created_at >= ?',
+				`SELECT COALESCE(SUM(reserved_micros), 0) AS total,
+				COALESCE(SUM(CASE WHEN kind = 'assistant' THEN 1 ELSE 0 END), 0) AS assistantTurnsToday,
+				COALESCE(SUM(CASE WHEN kind = 'media' THEN 1 ELSE 0 END), 0) AS mediaJobsToday
+				FROM tools_ai_usage WHERE user_id = ? AND created_at >= ?`,
 				userId,
 				dayStart
 			)
-			.one().total;
+			.one();
 		return {
 			assistantTurnsThisHour: hour.assistantTurnsThisHour,
 			mediaJobsThisHour: hour.mediaJobsThisHour,
-			estimatedReservedTodayUsd: spent / MILLION,
+			assistantTurnsToday: day.assistantTurnsToday,
+			mediaJobsToday: day.mediaJobsToday,
+			estimatedReservedTodayUsd: day.total / MILLION,
 			hourResetsAt: new Date((hour.firstAt ?? now) + HOUR_MS).toISOString(),
 			dayResetsAt: new Date(dayStart + DAY_MS).toISOString()
 		};


### PR DESCRIPTION
## Changes

- Aggregate assistant and media admissions since midnight UTC in the existing usage summary query, alongside the existing daily reservation total.
- Display assistant turns today and generations today, with a UTC label. Remove misleading hourly denominators from daily counts.
- Keep sliding hourly enforcement, daily funding guards, owner exemption, tenant authorization and retention unchanged. No schema changes.

## Verification

525 unit tests,24 compiled Tools hub/logs browser tests,check0/0 and production build passed. Coverage verifies UTC midnight inclusion/reset, older-than-one-hour daily counts, failed admissions, account isolation, unchanged hourly limits, and distinct daily values in the receipt. Phone/tablet/split/desktop layout regression passes.

Companion-first rollout for additive summary fields, followed by automatic main build. No paid inference or credentials changed.
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/swyxio/swyxdotio/pull/584?analyze=true)

<a href="https://staging.itsdev.in/review/swyxio/swyxdotio/pull/584" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-staging-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-staging-light.svg?v=3" alt="Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/swyxio/swyxdotio/pull/584" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->