### PR TITLE
Make About sponsorships easy to scan

### DIFF
--- a/src/lib/about/SponsorshipOption.svelte
+++ b/src/lib/about/SponsorshipOption.svelte
@@ -1,0 +1,162 @@
+<script>
+	/** @type {string} */
+	export let name;
+	/** @type {string} */
+	export let logo;
+	/** @type {string} */
+	export let description;
+	/** @type {string} */
+	export let contact;
+	/** @type {string} */
+	export let source;
+	/** @type {{value: string, label: string}[]} */
+	export let stats;
+	export let monochrome = false;
+</script>
+
+<div class="sponsorship-option">
+	<header>
+		<img src={logo} alt="" width="48" height="48" class:monochrome />
+		<div>
+			<h3>{name}</h3>
+			<p class="description">{description}</p>
+		</div>
+	</header>
+	<div class="sponsor-body">
+		<dl aria-label={`${name} audience milestones`}>
+			{#each stats as stat}
+				<div class="stat">
+					<dt>{stat.label}</dt>
+					<dd>{stat.value}</dd>
+				</div>
+			{/each}
+		</dl>
+		<div class="sponsor-actions">
+			<a class="sponsor-link" href={`mailto:${contact}`}
+				>Sponsor {name} <span aria-hidden="true">→</span></a
+			>
+			<a class="audience-link" href={source}>Audience details <span aria-hidden="true">↗</span></a>
+		</div>
+	</div>
+</div>
+
+<style>
+	.sponsorship-option {
+		margin: 1.6rem 0 1.6rem 0.8rem;
+		padding: 0.25rem 0 0.25rem 1.25rem;
+		border-left: 2px solid var(--page-border);
+	}
+	header {
+		display: grid;
+		grid-template-columns: 48px minmax(0, 1fr);
+		align-items: center;
+		gap: 1rem;
+	}
+	img {
+		width: 48px;
+		height: 48px;
+		object-fit: contain;
+		background: transparent;
+		margin: 0;
+	}
+	.monochrome {
+		filter: invert(1);
+	}
+	:global(.dark) .monochrome {
+		filter: none;
+	}
+	h3 {
+		margin: 0;
+		font: 700 1.4rem/1.2 var(--font-reading);
+	}
+	.description {
+		margin: 0.35rem 0 0;
+		color: var(--page-muted);
+		font: 0.9rem/1.5 var(--font-reading);
+	}
+	.sponsor-body {
+		margin-left: 4rem;
+	}
+	dl {
+		display: grid;
+		grid-template-columns: repeat(3, minmax(0, 1fr));
+		gap: 1rem;
+		margin: 1rem 0;
+	}
+	.stat {
+		display: grid;
+		grid-template-rows: auto 1fr;
+		gap: 0.25rem;
+	}
+	dt {
+		grid-row: 2;
+		color: var(--page-muted);
+		font: 0.85rem/1.4 var(--font-body);
+	}
+	dd {
+		grid-row: 1;
+		margin: 0;
+		font: 700 1.65rem/1.15 var(--font-reading);
+		font-variant-numeric: tabular-nums;
+		white-space: nowrap;
+	}
+	.sponsor-actions {
+		display: flex;
+		align-items: center;
+		flex-wrap: wrap;
+		gap: 0.35rem 1.1rem;
+		font: 0.9rem/1.4 var(--font-reading);
+	}
+	.sponsor-link {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.7rem;
+		min-height: 44px;
+		padding: 0.45rem 0.75rem;
+		border: 1px solid var(--page-link);
+		font-weight: 600;
+		text-decoration: none;
+	}
+	.sponsor-link:hover {
+		text-decoration: underline;
+	}
+	.audience-link {
+		padding-block: 0.75rem;
+	}
+	a:focus-visible {
+		outline: 2px solid var(--page-link);
+		outline-offset: 3px;
+	}
+	@media (max-width: 600px) {
+		.sponsorship-option {
+			margin-left: 0.25rem;
+			padding-left: 0.85rem;
+		}
+		header {
+			gap: 0.75rem;
+		}
+		.sponsor-body {
+			margin-left: 0;
+		}
+		dl {
+			grid-template-columns: 1fr;
+			gap: 0;
+		}
+		.stat {
+			grid-template-columns: 8rem minmax(0, 1fr);
+			grid-template-rows: auto;
+			align-items: center;
+			gap: 0.75rem;
+			padding-block: 0.65rem;
+			border-bottom: 1px solid var(--page-border);
+		}
+		dt {
+			grid-column: 2;
+			grid-row: 1;
+		}
+		dd {
+			grid-column: 1;
+			font-size: 1.4rem;
+		}
+	}
+</style>

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -1,4 +1,5 @@
 <script>
+	import SponsorshipOption from '$lib/about/SponsorshipOption.svelte';
 	import SocialMeta from '../../components/SocialMeta.svelte';
 	import { getPageSocialMeta } from '$lib/social-meta';
 	import LetterSection from '$lib/about/LetterSection.svelte';
@@ -204,29 +205,31 @@
 			Want to support what I’m building and reach the people building with AI? I work with sponsors
 			through <strong>AI Engineer</strong> and <strong>Latent Space</strong>.
 		</p>
-		<h3>AI Engineer — meet the builders</h3>
-		<p>
-			Technical conferences, expos, and workshops for AI engineers, founders, and technical leaders.
-			<strong>15,000+ in-person AI engineers</strong>,
-			<strong>100,000+ newsletter subscribers</strong>, and
-			<strong>10M+ talk &amp; workshop views in 2025</strong>.
-			<a href="https://ai.engineer/about">More about the AIE audience ↗</a>
-		</p>
-		<p>
-			<a href="mailto:sponsorships@ai.engineer">Sponsor AI Engineer →</a>
-		</p>
-		<h3>Latent Space — be part of the conversation</h3>
-		<p>
-			Our technical AI newsletter, podcast, and community have passed <strong
-				>200,000 subscribers</strong
-			>
-			and <strong>10M viewers across all channels</strong>. The podcast has ranked in the
-			<strong>Top 30 for US Technology on Apple Podcasts</strong>.
-			<a href="https://www.latent.space/about">More about the Latent Space audience ↗</a>
-		</p>
-		<p>
-			<a href="mailto:business@latent.space">Sponsor Latent Space →</a>
-		</p>
+		<SponsorshipOption
+			name="AI Engineer"
+			logo="/assets/ai-engineer-logo.svg"
+			monochrome
+			description="Conferences, expos & workshops for the people building AI."
+			contact="sponsorships@ai.engineer"
+			source="https://ai.engineer/about"
+			stats={[
+				{ value: '15,000+', label: 'In-person AI engineers' },
+				{ value: '100,000+', label: 'Newsletter subscribers' },
+				{ value: '10M+', label: 'Talk & workshop views in 2025' }
+			]}
+		/>
+		<SponsorshipOption
+			name="Latent Space"
+			logo="/assets/latent-space-hex-gradient.png"
+			description="Technical AI conversations, in your inbox and headphones."
+			contact="business@latent.space"
+			source="https://www.latent.space/about"
+			stats={[
+				{ value: '200,000+', label: 'Subscribers across all channels' },
+				{ value: '10M+', label: 'Viewers across all channels' },
+				{ value: 'Top 30', label: 'US Technology on Apple Podcasts (historical ranking)' }
+			]}
+		/>
 		<svelte:fragment slot="commentary"
 			><p>
 				If you’re building something useful for AI engineers, these are the two places where I can

--- a/tests/about-letter.test.mjs
+++ b/tests/about-letter.test.mjs
@@ -57,17 +57,28 @@ test('sponsorship replaces speaking navigation with sourced audience milestones 
 	assert.match(page, /<LetterSection id="sponsor" title="Sponsor my work"/);
 	assert.doesNotMatch(page, /Invite me to speak|href="#speaking"/);
 	for (const contact of ['sponsorships@ai.engineer', 'business@latent.space']) {
-		assert.ok(page.includes(`href="mailto:${contact}"`));
+		assert.ok(page.includes(`contact="${contact}"`));
 	}
 	for (const source of ['https://ai.engineer/about', 'https://www.latent.space/about']) {
-		assert.ok(page.includes(`href="${source}"`));
+		assert.ok(page.includes(`source="${source}"`));
 	}
-	assert.match(page, /15,000\+ in-person AI engineers/);
-	assert.match(page, /100,000\+ newsletter subscribers/);
-	assert.match(page, /10M\+ talk &amp; workshop views in 2025/);
-	assert.match(page, /200,000 subscribers/);
-	assert.match(page, /10M viewers across all channels/);
-	assert.match(page, /Top 30 for US Technology on Apple Podcasts/);
+	assert.match(page, /value: '15,000\+', label: 'In-person AI engineers'/);
+	assert.match(page, /value: '100,000\+', label: 'Newsletter subscribers'/);
+	assert.match(page, /value: '10M\+', label: 'Talk & workshop views in 2025'/);
+	assert.match(page, /value: '200,000\+', label: 'Subscribers across all channels'/);
+	assert.match(page, /value: '10M\+', label: 'Viewers across all channels'/);
+	assert.match(page, /US Technology on Apple Podcasts \(historical ranking\)/);
+	for (const logo of ['ai-engineer-logo.svg', 'latent-space-hex-gradient.png']) {
+		assert.ok(page.includes(`logo="/assets/${logo}"`));
+	}
+	const component = await read('src/lib/about/SponsorshipOption.svelte');
+	assert.match(component, /<dl aria-label=/);
+	assert.match(component, /<dt>\{stat.label\}<\/dt>/);
+	assert.match(component, /<dd>\{stat.value\}<\/dd>/);
+	assert.match(component, /href=\{`mailto:\$\{contact\}`\}/);
+	assert.match(component, /@media \(max-width: 600px\)/);
+	assert.match(component, /white-space: nowrap/);
+	assert.match(component, /grid-template-columns: 8rem minmax\(0, 1fr\)/);
 	assert.match(page, /Selected talks &amp; conversations/);
 	assert.match(page, /href="\/ai-eng-agents"/);
 });


### PR DESCRIPTION
Replace the dense sponsorship paragraphs with two logo-led, indented options. Reuses the real AIE and Latent Space logos already used on Home. Each option has three distinct number/label metrics, an outlined sponsor CTA, and a secondary audience-source link. Retains the personal-letter styling and margin commentary.

On phones, metrics become aligned number/label rows; numbers are explicitly non-wrapping. AIE logo adapts to light/dark themes. Sponsorship contacts, source links, historical ranking qualification, and talks/photos remain intact.

Verified visually at 1280/light, 720/light, and 390/dark with a targeted correction for wrapped phone numbers. Both logos load; no horizontal overflow. 529 tests pass, clean typecheck, successful production build.
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/swyxio/swyxdotio/pull/585?analyze=true)

<a href="https://staging.itsdev.in/review/swyxio/swyxdotio/pull/585" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-staging-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-staging-light.svg?v=3" alt="Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/swyxio/swyxdotio/pull/585" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->