### PR TITLE
Add photo-led native thumbnail defaults

### DIFF
--- a/src/lib/DrawDesignPreview.svelte
+++ b/src/lib/DrawDesignPreview.svelte
@@ -1,0 +1,90 @@
+<script lang="ts">
+	import { createDrawingDesign, DRAW_DESIGN_DEMO_PHOTO } from './draw-designs.js';
+	let {
+		templateId,
+		photoUrl = DRAW_DESIGN_DEMO_PHOTO.url
+	}: { templateId: string; photoUrl?: string } = $props();
+	const design = $derived(createDrawingDesign(templateId, { logoFileId: 'preview-logo' }));
+	const markerId = $props.id();
+</script>
+
+<!-- Render the native design definition, including the same public demo photo. -->
+<svg
+	viewBox={`0 0 ${design.format.width} ${design.format.height}`}
+	role="img"
+	aria-label={`${design.template.label} editable layout preview`}
+>
+	<defs
+		><marker
+			id={markerId}
+			viewBox="0 0 10 10"
+			refX="9"
+			refY="5"
+			markerWidth="3"
+			markerHeight="3"
+			orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#ff293b" /></marker
+		></defs
+	>
+	{#each design.elements as element}
+		{#if element.type === 'rectangle'}
+			<rect
+				x={element.x}
+				y={element.y}
+				width={element.width}
+				height={element.height}
+				fill={element.backgroundColor}
+				stroke={element.strokeColor}
+				stroke-width={element.strokeWidth}
+			/>
+		{:else if element.type === 'text'}
+			<text
+				x={element.x}
+				y={element.y + element.fontSize * 0.9}
+				fill={element.strokeColor}
+				font-size={element.fontSize}
+				font-family={element.fontFamily === 7
+					? 'Lilita One'
+					: element.fontFamily === 3
+						? 'Cascadia, monospace'
+						: 'Helvetica, Arial, sans-serif'}
+			>
+				{#each element.text.split('\n') as line, index}<tspan
+						x={element.x}
+						dy={index ? element.fontSize * element.lineHeight : 0}>{line}</tspan
+					>{/each}
+			</text>
+		{:else if element.type === 'image'}
+			<image
+				href={element.fileId === 'preview-logo'
+					? '/assets/latent-space-hex-gradient.png'
+					: photoUrl}
+				x={element.x}
+				y={element.y}
+				width={element.width}
+				height={element.height}
+				preserveAspectRatio="xMidYMid slice"
+			/>
+		{:else if element.type === 'line' || element.type === 'arrow'}
+			<polyline
+				points={element.points
+					.map(([x, y]: number[]) => `${element.x + x},${element.y + y}`)
+					.join(' ')}
+				fill="none"
+				stroke={element.strokeColor}
+				stroke-width={element.strokeWidth}
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				marker-end={element.type === 'arrow' ? `url(#${markerId})` : undefined}
+			/>
+		{/if}
+	{/each}
+</svg>
+
+<style>
+	svg {
+		display: block;
+		width: 100%;
+		height: auto;
+		border-radius: 5px;
+	}
+</style>

--- a/src/lib/draw-designs.js
+++ b/src/lib/draw-designs.js
@@ -12,7 +12,7 @@ export const DRAW_AGENT_WORKFLOWS = /** @type {const} */ ([
 		id: 'ls-thumbnail',
 		label: 'Podcast thumbnail',
 		prompt:
-			'Create a Latent Space YouTube thumbnail using the ls-podcast design template. Keep the official logo, near-black background, one huge 2–6 word curiosity hook, acid-lime emphasis, an editable guest-photo placeholder, company rail, and empty bottom-right YouTube timestamp zone. Inspect the result and improve spacing.'
+			'Create a Latent Space YouTube thumbnail using the ls-podcast design template. Keep the official logo, near-black background, one huge 2–6 word curiosity hook, acid-lime emphasis, a large real guest photo, a high-contrast claim, any explicitly supplied companies, and empty bottom-right YouTube timestamp zone. Inspect the result and improve spacing.'
 	},
 	{
 		id: 'fde-variants',
@@ -63,7 +63,8 @@ export const DRAW_DESIGN_TEMPLATES = Object.freeze([
 	{
 		id: 'ls-podcast',
 		label: 'Latent Space thumbnail',
-		description: 'Official logo, guest portrait, curiosity hook, and timestamp-safe company rail.',
+		description:
+			'Big claim + guest. Tight portrait, oversized headline, and one red emphasis band.',
 		format: 'youtube',
 		brand: 'latent-space',
 		accent: '#c8ff47',
@@ -72,16 +73,28 @@ export const DRAW_DESIGN_TEMPLATES = Object.freeze([
 	{
 		id: 'fde-decision',
 		label: 'FDE episode thumbnail',
-		description: 'A sharp split-layout debate with LS × FDE branding and editable cast area.',
+		description:
+			'Comparison + guest. A bright before/after contrast with a large central portrait.',
 		format: 'youtube',
 		brand: 'latent-space',
 		accent: '#b9a1ff',
-		background: '#13101d'
+		background: '#f7f7f4'
+	},
+	{
+		id: 'thumbnail-evidence',
+		label: 'Evidence + reaction thumbnail',
+		description:
+			'A concrete detail beside a guest. Editable sample instructions, a red arrow, and one question.',
+		format: 'youtube',
+		brand: 'latent-space',
+		accent: '#ff293b',
+		background: '#121317'
 	},
 	{
 		id: 'aie-speaker',
 		label: 'AI Engineer speaker card',
-		description: 'Portrait-format conference announcement with a bold orange speaker treatment.',
+		description:
+			'Portrait announcement concept, not an approved AI Engineer video-thumbnail style.',
 		format: 'portrait',
 		brand: 'ai-engineer',
 		accent: '#ff6b35',
@@ -150,7 +163,8 @@ function text(x, y, content, size, color, options = {}) {
 		y,
 		text: content,
 		fontSize: size,
-		fontFamily: 2,
+		fontFamily: size >= 60 ? 7 : 2,
+		lineHeight: size >= 60 ? 1.05 : 1.25,
 		strokeColor: color,
 		strokeWidth: 1,
 		strokeStyle: 'solid',
@@ -161,9 +175,12 @@ function text(x, y, content, size, color, options = {}) {
 }
 
 /** @param {string} headline @param {number} preferredSize */
-function fitThumbnailHeadline(headline, preferredSize) {
-	const availableWidth = 700;
-	const availableHeight = 225;
+function fitThumbnailHeadline(
+	headline,
+	preferredSize,
+	availableWidth = 610,
+	availableHeight = 380
+) {
 	let size = preferredSize;
 	let lines = [headline];
 	for (let attempt = 0; attempt < 3; attempt++) {
@@ -191,33 +208,64 @@ function fitThumbnailHeadline(headline, preferredSize) {
 	return { text: lines.join('\n'), size };
 }
 
-/** @param {number} x @param {number} y @param {number} width @param {number} height @param {string} accent */
-function portraitPlaceholder(x, y, width, height, accent) {
-	return [
-		rectangle(x, y, width, height, '#211f2c', { stroke: accent, dashed: true }),
-		{
-			id: id(),
-			type: 'ellipse',
-			x: x + width / 2 - 46,
-			y: y + height * 0.3,
-			width: 92,
-			height: 92,
-			strokeColor: accent,
-			backgroundColor: '#302d3c',
-			fillStyle: 'solid',
-			strokeWidth: 2,
-			strokeStyle: 'solid',
-			roughness: 0
+/** Public demo asset, already published in /about/photos. Never a private library photo. */
+export const DRAW_DESIGN_DEMO_PHOTO = Object.freeze({
+	id: 'draw-public-swyx-headshot',
+	url: '/about-photos/headshot-transparent.webp',
+	width: 420,
+	height: 420
+});
+
+/** @typedef {{ fileId: string, width: number, height: number }} DesignPhoto */
+
+/** Center-crop in the native image layer; its original bytes stay available for recropping.
+ * @param {number} x @param {number} y @param {number} width @param {number} height @param {DesignPhoto} photo */
+function portrait(x, y, width, height, photo) {
+	const scale = Math.max(width / photo.width, height / photo.height);
+	const cropWidth = width / scale;
+	const cropHeight = height / scale;
+	return {
+		id: id(),
+		type: 'image',
+		x,
+		y,
+		width,
+		height,
+		fileId: photo.fileId,
+		status: 'saved',
+		scale: [1, 1],
+		crop: {
+			x: (photo.width - cropWidth) / 2,
+			y: (photo.height - cropHeight) / 2,
+			width: cropWidth,
+			height: cropHeight,
+			naturalWidth: photo.width,
+			naturalHeight: photo.height
 		},
-		text(x + Math.max(22, (width - 190) / 2), y + height * 0.7, 'DROP GUEST PHOTO', 16, '#c2bed0')
-	];
+		customData: { designRole: 'guest-photo' }
+	};
+}
+
+/** @param {number} x @param {number} y @param {number[][]} points @param {string} color @param {number} [width] @param {boolean} [arrow] */
+function stroke(x, y, points, color, width = 14, arrow = false) {
+	return {
+		id: id(),
+		type: arrow ? 'arrow' : 'line',
+		x,
+		y,
+		points,
+		strokeColor: color,
+		strokeWidth: width,
+		roughness: 0,
+		endArrowhead: arrow ? 'triangle' : null
+	};
 }
 
 /**
  * Build a native Excalidraw frame with independently editable children. Logo
  * images are attached separately from the official supplied brand asset.
  * @param {string} templateId
- * @param {{ headline?: string, subtitle?: string, name?: string, companies?: string, logoFileId?: string, x?: number, y?: number }} [options]
+ * @param {{ headline?: string, subtitle?: string, name?: string, companies?: string, logoFileId?: string, photo?: DesignPhoto, x?: number, y?: number }} [options]
  */
 export function createDrawingDesign(templateId, options = {}) {
 	const template = getDrawingDesignTemplate(templateId);
@@ -231,53 +279,152 @@ export function createDrawingDesign(templateId, options = {}) {
 	let children = [rectangle(ox, oy, width, height, template.background)];
 	const headline = options.headline?.trim().slice(0, 120);
 	const subtitle = options.subtitle?.trim().slice(0, 140);
-	const companies = options.companies?.trim().slice(0, 100) ?? 'COMPANY ONE   ·   COMPANY TWO';
-	if (templateId === 'ls-podcast' || templateId === 'fde-decision') {
-		const fde = templateId === 'fde-decision';
-		const fittedHeadline = fitThumbnailHeadline(
-			headline ?? (fde ? 'WHAT CHANGES\nWHEN AI SHIPS?' : 'YOUR SHARPEST\nIDEA HERE'),
-			fde ? 76 : 86
-		);
-		children.push(
-			rectangle(ox + 64, oy + 103, 64, 7, template.accent),
-			text(ox + 66, oy + 140, fittedHeadline.text, fittedHeadline.size, '#ffffff'),
-			text(
-				ox + 68,
-				oy + 387,
-				fde ? 'THE BET THAT MATTERS' : 'THE AI ENGINEER PODCAST',
-				22,
-				template.accent
-			),
-			text(ox + 68, oy + 450, subtitle ?? 'One specific idea worth clicking.', 19, '#bcb8c7'),
-			...portraitPlaceholder(ox + 790, oy + 135, 400, 440, template.accent),
-			rectangle(ox + 64, oy + 614, 926, 2, '#373442'),
-			text(ox + 69, oy + 640, companies, 17, '#e3e0ed'),
-			text(
-				ox + 1030,
-				oy + 57,
-				fde ? 'LATENT SPACE × FDE' : 'LATENT SPACE',
-				fde ? 12 : 15,
-				'#ffffff'
-			)
-		);
-		if (options.logoFileId) {
+	const companies = options.companies?.trim().slice(0, 100);
+	const photo = options.photo ?? { fileId: DRAW_DESIGN_DEMO_PHOTO.id, ...DRAW_DESIGN_DEMO_PHOTO };
+	if (
+		!Number.isFinite(photo.width) ||
+		!Number.isFinite(photo.height) ||
+		photo.width <= 0 ||
+		photo.height <= 0
+	)
+		throw new Error('Choose a photo with valid dimensions.');
+	if (template.format === 'youtube') {
+		if (templateId === 'ls-podcast') {
+			// A face at feed scale, a single claim, and one meaningful emphasis color.
+			children.push(portrait(ox + 640, oy + 80, 640, 640, photo));
+			const fitted = fitThumbnailHeadline(headline || 'CODE IS\nTHE EASY\nPART.', 122, 605, 435);
+			const lines = fitted.text.split('\n');
+			const lineHeight = fitted.size * 1.05;
+			const emphasisY = oy + 130 + (lines.length - 1) * lineHeight;
+			children.push(
+				rectangle(
+					ox + 44,
+					emphasisY - 2,
+					Math.min(604, (lines.at(-1)?.length ?? 0) * fitted.size * 0.65 + 28),
+					lineHeight + 6,
+					'#ed1835'
+				),
+				{
+					...text(ox + 54, oy + 130, fitted.text, fitted.size, '#ffffff'),
+					customData: { designRole: 'headline' }
+				}
+			);
+		} else if (templateId === 'fde-decision') {
+			// Three clear regions: two opposing labels and a real person between them.
+			children.push(portrait(ox + 350, oy + 120, 580, 600, photo));
+			const fitted = fitThumbnailHeadline(headline || 'WHAT ACTUALLY WORKS?', 76, 1080, 90);
+			children.push(
+				{
+					...text(ox + 44, oy + 35, fitted.text, fitted.size, '#111114'),
+					customData: { designRole: 'headline' }
+				},
+				text(ox + 46, oy + 280, 'MORE', 38, '#77777c'),
+				text(ox + 42, oy + 330, 'PROMPTS', 68, '#d72032'),
+				text(ox + 951, oy + 280, 'BETTER', 38, '#77777c'),
+				text(ox + 935, oy + 330, 'SYSTEMS', 65, '#15834b'),
+				stroke(
+					ox + 138,
+					oy + 465,
+					[
+						[0, 0],
+						[84, 84]
+					],
+					'#e42b3e',
+					20
+				),
+				stroke(
+					ox + 222,
+					oy + 465,
+					[
+						[0, 0],
+						[-84, 84]
+					],
+					'#e42b3e',
+					20
+				),
+				stroke(
+					ox + 1030,
+					oy + 510,
+					[
+						[0, 0],
+						[30, 30],
+						[100, -56]
+					],
+					'#15834b',
+					20
+				)
+			);
+		} else {
+			// An explicitly labelled sample document, not a fabricated screenshot or quote.
+			const fitted = fitThumbnailHeadline(headline || 'TOO MUCH\nCONTEXT?', 112, 730, 245);
+			children.push(
+				{
+					...text(ox + 44, oy + 50, fitted.text, fitted.size, '#ffffff'),
+					customData: { designRole: 'headline' }
+				},
+				rectangle(ox + 44, oy + 340, 692, 294, '#f5f5f3'),
+				{ ...text(ox + 76, oy + 366, 'AGENTS.md', 36, '#16171c'), fontFamily: 3 },
+				rectangle(ox + 76, oy + 422, 600, 2, '#d5d5d5'),
+				{
+					...text(
+						ox + 76,
+						oy + 450,
+						'Keep it short.\nUse the right tools.\nCheck your work.',
+						32,
+						'#34353a'
+					),
+					fontFamily: 3
+				},
+				stroke(
+					ox + 672,
+					oy + 295,
+					[
+						[0, 0],
+						[25, 55],
+						[-28, 102]
+					],
+					'#ff293b',
+					15,
+					true
+				),
+				portrait(ox + 742, oy + 135, 538, 585, photo)
+			);
+		}
+		// The compact identity is constant; the composition does not have to be purple.
+		if (options.logoFileId)
 			children.push({
 				id: id(),
 				type: 'image',
-				x: ox + 970,
-				y: oy + 38,
+				x: ox + 1168,
+				y: oy + 26,
 				width: 50,
 				height: 50,
 				fileId: options.logoFileId,
-				status: 'saved'
+				status: 'saved',
+				customData: { designRole: 'brand-logo' }
 			});
-		}
+		if (templateId === 'fde-decision')
+			children.push(text(ox + 1222, oy + 43, 'FDE', 16, '#19191d'));
+		if (subtitle)
+			children.push(
+				text(ox + 50, oy + 644, subtitle, 19, templateId === 'fde-decision' ? '#303037' : '#eeeeee')
+			);
+		if (companies)
+			children.push(
+				text(
+					ox + 50,
+					oy + 680,
+					companies,
+					16,
+					templateId === 'fde-decision' ? '#303037' : '#eeeeee'
+				)
+			);
 	} else if (templateId === 'aie-speaker') {
 		children.push(
 			rectangle(ox, oy, width, 28, template.accent),
 			text(ox + 74, oy + 85, 'AI ENGINEER', 29, '#ffffff'),
 			text(ox + 75, oy + 130, 'EUROPE', 22, template.accent),
-			...portraitPlaceholder(ox + 96, oy + 223, 888, 690, template.accent),
+			portrait(ox + 160, oy + 223, 760, 690, photo),
 			text(ox + 78, oy + 964, headline ?? 'SPEAKER\nNAME', 92, '#ffffff'),
 			text(ox + 82, oy + 1190, subtitle ?? 'The talk title goes here', 29, '#d2ced5'),
 			rectangle(ox + 80, oy + 1280, 116, 5, template.accent)

--- a/src/routes/tools/draw/+page.svelte
+++ b/src/routes/tools/draw/+page.svelte
@@ -28,6 +28,7 @@
 	} from '$lib/draw-image-scene.js';
 	import {
 		createDrawingDesign,
+		DRAW_DESIGN_DEMO_PHOTO,
 		DRAW_DESIGN_FORMATS,
 		DRAW_DESIGN_TEMPLATES,
 		getDrawingDesignFormat,
@@ -38,6 +39,7 @@
 	import { DRAW_ILLUSTRATION_BRUSHES, applyIllustrationBrush } from '$lib/draw-illustration.js';
 	import DrawImageToolbox from '$lib/DrawImageToolbox.svelte';
 	import DrawWorkspaceNav from '$lib/DrawWorkspaceNav.svelte';
+	import DrawDesignPreview from '$lib/DrawDesignPreview.svelte';
 	import DrawStartingPoints from '$lib/DrawStartingPoints.svelte';
 	import {
 		getDrawingStartingMode,
@@ -176,6 +178,7 @@
 	let legacyCachePageId = '';
 	let isSwitchingPage = $state(false);
 	let isLibraryOpen = $state(false);
+	let useSelectedDesignPhoto = $state(false);
 	let selectedImageId = $state('');
 	let selectedImageDataUrl = $state('');
 	let imageToolAction = $state(
@@ -1403,28 +1406,23 @@
 		});
 	}
 
-	async function loadOfficialBrandLogo() {
-		if (!editor) throw new Error('The drawing editor is unavailable.');
-		const fileId = /** @type {import('@excalidraw/excalidraw/element/types').FileId} */ (
-			'latent-space-official-hex'
-		);
-		if (editor.getFiles()[fileId]) return fileId;
-		const response = await fetch('/assets/latent-space-hex-gradient.png', { cache: 'force-cache' });
-		if (!response.ok) throw new Error('The official Latent Space logo could not be loaded.');
-		const image = await response.blob();
-		const dataURL = /** @type {import('@excalidraw/excalidraw/types').DataURL} */ (
-			await readBlobDataUrl(image)
-		);
-		editor.addFiles([
-			{
-				id: fileId,
-				mimeType: 'image/png',
-				dataURL,
-				created: Date.now(),
-				lastRetrieved: Date.now()
-			}
-		]);
-		return fileId;
+	/** Load public starter assets without modifying the canvas before scope is rechecked.
+	 * @param {string} id @param {string} url @param {'image/png' | 'image/webp'} mimeType */
+	async function loadDesignImageAsset(id, url, mimeType) {
+		const existing = editor?.getFiles()[id];
+		if (existing) return existing;
+		const response = await fetch(url, { cache: 'force-cache' });
+		if (!response.ok)
+			throw new Error('The template image could not be loaded. Try inserting again.');
+		return {
+			id: /** @type {import('@excalidraw/excalidraw/element/types').FileId} */ (id),
+			mimeType,
+			dataURL: /** @type {import('@excalidraw/excalidraw/types').DataURL} */ (
+				await readBlobDataUrl(await response.blob())
+			),
+			created: Date.now(),
+			lastRetrieved: Date.now()
+		};
 	}
 
 	/** @param {readonly import('@excalidraw/excalidraw/element/types').ExcalidrawElement[]} elements */
@@ -1447,22 +1445,82 @@
 		});
 	}
 
-	/** @param {string} templateId @param {Record<string, string>} [options] */
-	async function insertDesign(templateId, options = {}) {
+	/** @param {string} templateId @param {Record<string, string>} [options] @param {boolean} [useSelectedPhoto] */
+	async function insertDesign(templateId, options = {}, useSelectedPhoto = false) {
 		const activityUser = toolsUser?.id;
 		if (!editor || !convertElements || !captureImmediately)
 			throw new Error('The drawing canvas is not ready.');
 		const template = getDrawingDesignTemplate(templateId);
 		if (!template) throw new Error('Choose one of the available design templates.');
+		const insertionPage = activePageId;
+		const insertionAccount = STORAGE_KEY;
+		const insertionEditor = editor;
+		function assertInsertionScope() {
+			if (
+				activePageId !== insertionPage ||
+				STORAGE_KEY !== insertionAccount ||
+				editor !== insertionEditor ||
+				accountChanged
+			)
+				throw new Error('The account or page changed. Nothing was inserted.');
+		}
+		const needsPhoto = template.format === 'youtube' || template.id === 'aie-speaker';
+		const selected = editor
+			.getSceneElements()
+			.find((element) => element.id === selectedImageId && element.type === 'image');
+		const selectedFile =
+			selected?.type === 'image' && selected.fileId
+				? editor.getFiles()[selected.fileId]
+				: undefined;
+		if (needsPhoto && useSelectedPhoto && !selectedFile)
+			throw new Error('Select a canvas image to use as the guest photo.');
+		await Promise.all([
+			document.fonts.load('100px "Lilita One"'),
+			document.fonts.load('32px Cascadia')
+		]);
+		assertInsertionScope();
+		const [logo, demo] = await Promise.all([
+			template.brand === 'latent-space'
+				? loadDesignImageAsset(
+						'latent-space-official-hex',
+						'/assets/latent-space-hex-gradient.png',
+						'image/png'
+					)
+				: undefined,
+			needsPhoto && !useSelectedPhoto
+				? loadDesignImageAsset(DRAW_DESIGN_DEMO_PHOTO.id, DRAW_DESIGN_DEMO_PHOTO.url, 'image/webp')
+				: undefined
+		]);
+		assertInsertionScope();
+		let photo;
+		if (needsPhoto && useSelectedPhoto && selectedFile) {
+			const bitmap = await createImageBitmap(
+				await fetch(selectedFile.dataURL).then((response) => response.blob())
+			);
+			photo = { fileId: selectedFile.id, width: bitmap.width, height: bitmap.height };
+			bitmap.close();
+		} else if (demo)
+			photo = {
+				fileId: demo.id,
+				width: DRAW_DESIGN_DEMO_PHOTO.width,
+				height: DRAW_DESIGN_DEMO_PHOTO.height
+			};
+		assertInsertionScope();
+		// Read after every async step: do not drop drawing edits made while assets were loading.
 		const existing = editor.getSceneElementsIncludingDeleted();
 		const visible = existing.filter((element) => !element.isDeleted);
 		const x = visible.length
 			? Math.max(...visible.map((element) => element.x + element.width)) + 120
 			: 0;
 		const y = visible.length ? Math.min(...visible.map((element) => element.y)) : 0;
-		const logoFileId =
-			template.brand === 'latent-space' ? await loadOfficialBrandLogo() : undefined;
-		const design = createDrawingDesign(templateId, { ...options, x, y, logoFileId });
+		const design = createDrawingDesign(templateId, {
+			...options,
+			x,
+			y,
+			logoFileId: logo?.id,
+			photo
+		});
+
 		const elements = convertElements(
 			/** @type {import('@excalidraw/excalidraw/data/transform').ExcalidrawElementSkeleton[]} */ (
 				design.elements
@@ -1471,6 +1529,11 @@
 		);
 		const frame = elements.find((element) => element.type === 'frame');
 		if (!frame) throw new Error('The design artboard could not be created.');
+		// Excalidraw treats a zero frame coordinate as absent and adds 10px padding.
+		// Restore our explicit origin before committing any new elements.
+		Object.assign(frame, { x, y });
+		const files = [logo, demo].filter((file) => !!file);
+		if (files.length) editor.addFiles(files);
 		editor.updateScene({
 			elements: [...existing, ...elements],
 			appState: { selectedElementIds: { [frame.id]: true } },
@@ -1529,6 +1592,7 @@
 		const copied = convertElements(/** @type {any} */ (skeletons), { regenerateIds: true });
 		const nextFrame = copied.find((element) => element.type === 'frame');
 		if (!nextFrame) throw new Error('The design artboard could not be duplicated.');
+		Object.assign(nextFrame, { x: nextX, y: frame.y });
 		editor.updateScene({
 			elements: [...existing, ...copied],
 			appState: { selectedElementIds: { [nextFrame.id]: true } },
@@ -2996,38 +3060,60 @@
 				aria-label="Branded design templates"
 			>
 				<div class="component-heading">
-					<strong>Create a real design</strong>
-					<span>Editable artboards, brand assets, and exact export sizes.</span>
+					<strong>Make it worth clicking.</strong>
+					<span>Big faces. Specific hooks. Editable 1280 × 720 artwork.</span>
 				</div>
-				{#each DRAW_DESIGN_TEMPLATES as design (design.id)}
+				<label class="design-photo-choice">
+					<input
+						type="checkbox"
+						checked={useSelectedDesignPhoto && !!selectedImageId}
+						disabled={!selectedImageId}
+						onchange={(event) => (useSelectedDesignPhoto = event.currentTarget.checked)}
+					/>
+					Use selected image as guest
+				</label>
+				<p class="design-demo-note">
+					{useSelectedDesignPhoto && selectedImageId
+						? 'Your selected image will be copied; the original stays untouched.'
+						: 'Demo: public photo of swyx + sample copy. Select your own canvas image to use it instead.'}
+				</p>
+				{#snippet designCard(design = DRAW_DESIGN_TEMPLATES[0])}
 					<button
 						type="button"
 						class="design-option"
 						aria-label="Insert {design.label} design"
-						onclick={() => void insertDesign(design.id)}
+						onclick={() =>
+							void insertDesign(design.id, {}, useSelectedDesignPhoto && !!selectedImageId).catch(
+								(error) => editor?.setToast({ message: error.message })
+							)}
 					>
-						<div class="design-preview" style:background={design.background}>
-							<div class="design-preview-copy">
-								<span style:background={design.accent}></span>
-								<strong
-									>{design.brand === 'latent-space'
-										? 'YOUR NEXT\nBIG IDEA'
-										: design.brand === 'ai-engineer'
-											? 'AI ENGINEER'
-											: 'THE IDEA\nTHAT MATTERS'}</strong
-								>
-							</div>
-							<div class="design-preview-portrait" style:border-color={design.accent}></div>
-						</div>
+						<DrawDesignPreview
+							templateId={design.id}
+							photoUrl={useSelectedDesignPhoto && selectedImageDataUrl
+								? selectedImageDataUrl
+								: undefined}
+						/>
 						<strong>{design.label}</strong>
 						<span>{design.description}</span>
 						<span class="design-dimensions"
 							>{getDrawingDesignFormat(design.format)?.width} × {getDrawingDesignFormat(
 								design.format
-							)?.height}</span
+							)?.height} · Editable layers</span
 						>
 					</button>
+				{/snippet}
+				{#each DRAW_DESIGN_TEMPLATES.filter((design) => design.format === 'youtube') as design (design.id)}
+					{@render designCard(design)}
 				{/each}
+				<details class="design-other-formats">
+					<summary>Other formats · speaker cards, articles & slides</summary>
+					<p>
+						Announcement and slide concepts are not approved AI Engineer video-thumbnail styles.
+					</p>
+					{#each DRAW_DESIGN_TEMPLATES.filter((design) => design.format !== 'youtube') as design (design.id)}
+						{@render designCard(design)}
+					{/each}
+				</details>
 			</section>
 		{:else if workspaceSection === 'components'}
 			<section id="drawing-components" class="workspace-content" aria-label="UI components">
@@ -3940,33 +4026,40 @@
 		color: #6252bb;
 		font-weight: 600;
 	}
-	.design-preview {
+	.design-photo-choice {
 		display: flex;
-		justify-content: space-between;
 		align-items: center;
-		min-height: 91px;
-		padding: 12px;
-		border-radius: 6px;
-	}
-	.design-preview-copy {
-		display: grid;
 		gap: 8px;
+		padding: 8px 10px;
+		font-size: 12px;
+		cursor: pointer;
 	}
-	.design-preview-copy > span {
-		width: 22px;
-		height: 3px;
+	.design-photo-choice input {
+		width: 18px;
+		height: 18px;
+		accent-color: #6252bb;
 	}
-	.design-preview-copy > strong {
-		color: #fff;
+	.design-demo-note {
+		margin: 0 10px 12px;
 		font-size: 11px;
-		line-height: 1.14;
-		white-space: pre-line;
+		line-height: 1.5;
+		color: #777080;
 	}
-	.design-preview-portrait {
-		width: 49px;
-		height: 61px;
-		border: 1px dashed;
-		background: #ffffff0b;
+	.design-other-formats {
+		margin-top: 12px;
+		border-top: 1px solid #e4dfec;
+	}
+	.design-other-formats summary {
+		cursor: pointer;
+		padding: 14px 10px;
+		font-size: 11px;
+		line-height: 1.5;
+	}
+	.design-other-formats p {
+		padding: 0 10px 10px;
+		font-size: 11px;
+		line-height: 1.5;
+		color: #777080;
 	}
 
 	.preset-preview {

--- a/tests/draw-agent-tools.test.mjs
+++ b/tests/draw-agent-tools.test.mjs
@@ -389,7 +389,7 @@ test('drawing assistant discovers branded templates and executes bounded design,
 		}
 	};
 	const catalog = /** @type {any} */ (await executeDrawingAgentCommand(['designs'], designContext));
-	assert.equal(catalog.templates.length, 5);
+	assert.equal(catalog.templates.length, 6);
 	assert.equal(catalog.formats.length, 6);
 	await executeDrawingAgentCommand(
 		['design', 'insert', 'ls-podcast', '--headline', 'USEFUL HOOK'],

--- a/tests/draw-designs.spec.js
+++ b/tests/draw-designs.spec.js
@@ -1,4 +1,4 @@
-import { readFile } from 'node:fs/promises';
+import { readFile, copyFile } from 'node:fs/promises';
 import { expect, test } from '@playwright/test';
 import { authenticateTools, TEST_TOOLS_OWNER, TEST_TOOLS_MEMBER } from './helpers/tools-auth.js';
 
@@ -26,11 +26,17 @@ async function scene(page) {
 test('branded thumbnail templates create exact editable frames with the official Latent Space logo', async ({
 	page
 }) => {
+	await page.setViewportSize({ width: 1280, height: 1300 });
 	await page.goto('/tools/draw');
 	await openDesignLibrary(page);
 	const library = page.getByRole('region', { name: 'Branded design templates' });
-	await expect(library.getByRole('button', { name: /^insert .+ design$/i })).toHaveCount(5);
+	await expect(library.getByRole('button', { name: /^insert .+ design$/i })).toHaveCount(3);
 	await expect(library).toContainText('1280 × 720');
+	await expect(library).toContainText('public photo of swyx');
+	await expect(library.getByRole('img')).toHaveCount(3);
+	await page.screenshot({ path: '/tmp/draw-photo-gallery-desktop.png' });
+	await page.evaluate(() => document.fonts.ready);
+	await library.screenshot({ path: '/tmp/draw-photo-cards.png' });
 	await library.getByRole('button', { name: 'Insert Latent Space thumbnail design' }).click();
 	await expect(page.getByRole('region', { name: 'Selected design artboard' })).toContainText(
 		'1280 × 720'
@@ -39,9 +45,18 @@ test('branded thumbnail templates create exact editable frames with the official
 	const frame = design.elements.find((element) => element.type === 'frame' && !element.isDeleted);
 	expect(frame.width).toBe(1280);
 	expect(frame.height).toBe(720);
+	expect([frame.x, frame.y]).toEqual([0, 0]);
+	const background = design.elements.find(
+		(e) =>
+			e.type === 'rectangle' &&
+			e.frameId === frame.id &&
+			e.width === frame.width &&
+			e.height === frame.height
+	);
+	expect([background.x, background.y]).toEqual([frame.x, frame.y]);
 	const children = design.elements.filter((element) => element.frameId === frame.id);
-	expect(children.some((element) => element.text === 'YOUR SHARPEST\nIDEA HERE')).toBe(true);
-	const logo = children.find((element) => element.type === 'image');
+	expect(children.some((element) => element.text === 'CODE IS\nTHE EASY\nPART.')).toBe(true);
+	const logo = children.find((element) => element.customData?.designRole === 'brand-logo');
 	expect(logo.fileId).toBe('latent-space-official-hex');
 	expect(design.files[logo.fileId].mimeType).toBe('image/png');
 	expect(
@@ -50,6 +65,17 @@ test('branded thumbnail templates create exact editable frames with the official
 		)
 	).toBe(false);
 	await expect(page.getByRole('button', { name: 'Undo' })).toBeEnabled();
+	await page.reload();
+	await expect(page.locator('.draw-canvas canvas.excalidraw__canvas.interactive')).toBeVisible();
+	const restored = await scene(page);
+	expect(restored.elements.find((e) => e.id === frame.id)).toMatchObject({
+		x: 0,
+		y: 0,
+		width: 1280,
+		height: 720
+	});
+	const restoredPhoto = restored.elements.find((e) => e.customData?.designRole === 'guest-photo');
+	expect(restored.files[restoredPhoto.fileId].dataURL).toMatch(/^data:image\/webp/);
 });
 
 test('artboards duplicate as editable variants, resize proportionally, and export exact-size PNG files', async ({
@@ -64,6 +90,15 @@ test('artboards duplicate as editable variants, resize proportionally, and expor
 	let frames = current.elements.filter((element) => element.type === 'frame' && !element.isDeleted);
 	expect(frames).toHaveLength(2);
 	expect(frames[1].name).toContain('Variant');
+	expect(frames[1].y).toBe(frames[0].y);
+	const duplicateBackground = current.elements.find(
+		(e) =>
+			e.type === 'rectangle' &&
+			e.frameId === frames[1].id &&
+			e.width === frames[1].width &&
+			e.height === frames[1].height
+	);
+	expect([duplicateBackground.x, duplicateBackground.y]).toEqual([frames[1].x, frames[1].y]);
 	await controls.getByRole('combobox', { name: 'Resize design artboard' }).selectOption('square');
 	await expect(controls).toContainText('1080 × 1080');
 	current = await scene(page);
@@ -82,6 +117,19 @@ test('artboards duplicate as editable variants, resize proportionally, and expor
 	expect(bytes.subarray(1, 4).toString()).toBe('PNG');
 	expect(bytes.readUInt32BE(16)).toBe(1080);
 	expect(bytes.readUInt32BE(20)).toBe(1080);
+	const corner = await page.evaluate(
+		async (dataURL) => {
+			const image = await createImageBitmap(await fetch(dataURL).then((r) => r.blob()));
+			const canvas = new OffscreenCanvas(image.width, image.height);
+			const context = canvas.getContext('2d');
+			if (!context) throw new Error('Missing test canvas');
+			context.drawImage(image, 0, 0);
+			image.close();
+			return Array.from(context.getImageData(2, 2, 1, 1).data);
+		},
+		'data:image/png;base64,' + bytes.toString('base64')
+	);
+	expect(corner).toEqual([247, 247, 244, 255]);
 	for (const [label, extension] of [
 		['Download design as JPG', 'jpg'],
 		['Download design as SVG', 'svg']
@@ -107,6 +155,7 @@ test('speaker designs use portrait dimensions and pages duplicate the complete e
 }) => {
 	await page.goto('/tools/draw');
 	await openDesignLibrary(page);
+	await page.getByText('Other formats · speaker cards, articles & slides', { exact: true }).click();
 	await page.getByRole('button', { name: 'Insert AI Engineer speaker card design' }).click();
 	await expect(page.getByRole('region', { name: 'Selected design artboard' })).toContainText(
 		'1080 × 1350'
@@ -186,7 +235,7 @@ test('authenticated assistant offers grounded Canva-style tasks and creates bran
 	const design = await scene(page);
 	const headline = design.elements.find((element) => element.text === 'HARNESS\nENGINEERING');
 	const portrait = design.elements.find(
-		(element) => element.type === 'rectangle' && element.strokeStyle === 'dashed'
+		(element) => element.customData?.designRole === 'guest-photo'
 	);
 	expect(headline.x + headline.width).toBeLessThan(portrait.x);
 });
@@ -199,10 +248,189 @@ test('design workflows remain reachable and artboard controls stay contained on 
 	await page.getByRole('button', { name: 'Choose drawing mode and tools' }).click();
 	await page.getByRole('button', { name: 'Open drawing templates and library' }).click();
 	await page.getByRole('tab', { name: 'Design', exact: true }).click();
+	await page.screenshot({ path: '/tmp/draw-photo-gallery-mobile.png' });
+	await page
+		.getByRole('button', { name: 'Insert Evidence + reaction thumbnail design' })
+		.scrollIntoViewIfNeeded();
+	await page.screenshot({ path: '/tmp/draw-photo-gallery-mobile-more.png' });
+	await page.getByText('Other formats · speaker cards, articles & slides', { exact: true }).click();
 	await page.getByRole('button', { name: 'Insert Article launch banner design' }).click();
 	const controls = page.getByRole('region', { name: 'Selected design artboard' });
 	await expect(controls).toBeVisible();
 	const bounds = await controls.boundingBox();
 	expect(bounds?.x).toBeGreaterThanOrEqual(0);
 	expect((bounds?.x ?? 0) + (bounds?.width ?? 0)).toBeLessThanOrEqual(390);
+});
+
+test('design insertion waits for its font, preserves intervening native edits, and does not cross pages', async ({
+	page
+}) => {
+	await page.goto('/tools/draw');
+	await openDesignLibrary(page);
+	await page.evaluate(() => {
+		const load = document.fonts.load.bind(document.fonts);
+		/** @type {(()=>void)[]} */ const pending = [];
+		document.fonts.load = (font, text) =>
+			font.startsWith('100px')
+				? new Promise((resolve, reject) =>
+						pending.push(() => load(font, text).then(resolve, reject))
+					)
+				: load(font, text);
+		/** @type {any} */ (window).__releaseDesignFonts = () =>
+			pending.splice(0).forEach((fn) => fn());
+	});
+	await page.getByRole('button', { name: 'Insert Latent Space thumbnail design' }).click();
+	await page.getByRole('tab', { name: 'Presets', exact: true }).click();
+	await page.getByRole('button', { name: 'Insert Priority quadrants preset' }).click();
+	await expect
+		.poll(async () => (await scene(page)).elements.filter((e) => !e.isDeleted).length)
+		.toBeGreaterThan(0);
+	const original = (await scene(page)).elements.filter((e) => !e.isDeleted).map((e) => e.id);
+	expect(original.length).toBeGreaterThan(0);
+	await page.evaluate(() => /** @type {any} */ (window).__releaseDesignFonts());
+	await expect
+		.poll(
+			async () =>
+				(await scene(page)).elements.filter((e) => e.type === 'frame' && !e.isDeleted).length
+		)
+		.toBe(1);
+	const inserted = (await scene(page)).elements.filter((e) => !e.isDeleted).map((e) => e.id);
+	expect(original.every((id) => inserted.includes(id))).toBe(true);
+	await page.getByRole('button', { name: 'Undo', exact: true }).click();
+	await expect
+		.poll(async () => (await scene(page)).elements.filter((e) => !e.isDeleted).map((e) => e.id))
+		.toEqual(original);
+	await openDesignLibrary(page);
+	await page.getByRole('button', { name: 'Insert Latent Space thumbnail design' }).click();
+	await page.getByTestId('sidebar-close').click();
+	await page.getByRole('button', { name: 'Manage drawing pages' }).click();
+	await page.getByRole('button', { name: 'New page', exact: true }).click();
+	await page.evaluate(() => /** @type {any} */ (window).__releaseDesignFonts());
+	await expect(
+		page.getByText('The account or page changed. Nothing was inserted.', { exact: true })
+	).toBeVisible();
+	expect((await scene(page)).elements.filter((e) => !e.isDeleted)).toHaveLength(0);
+});
+
+test('every starter renders its editable headline inside the real artboard', async ({ page }) => {
+	await page.goto('/tools/draw');
+	for (const [id, label] of [
+		['ls-podcast', 'Latent Space thumbnail'],
+		['fde-decision', 'FDE episode thumbnail'],
+		['thumbnail-evidence', 'Evidence + reaction thumbnail'],
+		['aie-speaker', 'AI Engineer speaker card'],
+		['blog-launch', 'Article launch banner'],
+		['keynote-slide', 'Conference title slide']
+	]) {
+		await openDesignLibrary(page);
+		const button = page.getByRole('button', { name: `Insert ${label} design`, exact: true });
+		if (!(await button.isVisible()))
+			await page
+				.getByText('Other formats · speaker cards, articles & slides', { exact: true })
+				.click();
+		await button.click();
+		const controls = page.getByRole('region', { name: 'Selected design artboard' });
+		await expect(controls).toContainText(label);
+		const drawing = await scene(page);
+		const frame = drawing.elements.find(
+			(e) => e.type === 'frame' && e.name === label && !e.isDeleted
+		);
+		for (const text of drawing.elements.filter(
+			(e) => e.frameId === frame.id && e.type === 'text'
+		)) {
+			expect(text.x, `${id}: ${text.text}`).toBeGreaterThanOrEqual(frame.x);
+			expect(text.y, `${id}: ${text.text}`).toBeGreaterThanOrEqual(frame.y);
+			expect(text.x + text.width, `${id}: ${text.text}`).toBeLessThanOrEqual(frame.x + frame.width);
+			expect(text.y + text.height, `${id}: ${text.text}`).toBeLessThanOrEqual(
+				frame.y + frame.height
+			);
+		}
+		const downloadEvent = page.waitForEvent('download');
+		await controls.getByRole('button', { name: 'Download design as PNG' }).click();
+		const path = await (await downloadEvent).path();
+		if (!path) throw new Error('No design export');
+		await copyFile(path, `/tmp/draw-photo-${id}.png`);
+	}
+});
+
+test('a chosen canvas photo is reused explicitly without replacing the original or calling a model', async ({
+	page
+}) => {
+	/** @type {string[]} */
+	const modelRequests = [];
+	page.on('request', (request) => {
+		if (/\/tools\/api\/(fal|draw\/generat|draw\/agent)/.test(request.url()))
+			modelRequests.push(request.url());
+	});
+	await page.goto('/tools/draw');
+	const canvas = page.locator('.draw-canvas canvas.excalidraw__canvas.interactive');
+	await expect(canvas).toBeVisible();
+	await canvas.click({ position: { x: 80, y: 170 } });
+	await page.evaluate(async () => {
+		const blob = await fetch('/swyx-ski.jpeg').then((r) => r.blob());
+		const transfer = new DataTransfer();
+		transfer.items.add(new File([blob], 'guest.jpg', { type: blob.type }));
+		document.dispatchEvent(
+			new ClipboardEvent('paste', { bubbles: true, cancelable: true, clipboardData: transfer })
+		);
+	});
+	await expect(page.getByRole('region', { name: 'Selected image tools' })).toBeVisible();
+	await expect
+		.poll(
+			async () =>
+				(await scene(page)).elements.filter((e) => e.type === 'image' && !e.isDeleted).length
+		)
+		.toBe(1);
+	await expect
+		.poll(async () => {
+			const drawing = await scene(page);
+			const image = drawing.elements.find((e) => e.type === 'image' && !e.isDeleted);
+			return !!drawing.files[image?.fileId];
+		})
+		.toBe(true);
+	const before = await scene(page);
+	const original = before.elements.find((e) => e.type === 'image');
+	await openDesignLibrary(page);
+	await page.getByRole('checkbox', { name: 'Use selected image as guest' }).check();
+	await page.getByRole('button', { name: 'Insert Latent Space thumbnail design' }).click();
+	await expect(page.getByRole('region', { name: 'Selected design artboard' })).toBeVisible();
+	const after = await scene(page);
+	const photo = after.elements.find(
+		(e) => e.customData?.designRole === 'guest-photo' && !e.isDeleted
+	);
+	expect(photo.fileId).toBe(original.fileId);
+	expect(after.files[photo.fileId].dataURL).toBe(before.files[original.fileId].dataURL);
+	const retained = after.elements.find((e) => e.id === original.id);
+	expect([retained.x, retained.y, retained.width, retained.height, retained.fileId]).toEqual([
+		original.x,
+		original.y,
+		original.width,
+		original.height,
+		original.fileId
+	]);
+	expect(after.files['draw-public-swyx-headshot']).toBeUndefined();
+	await page.getByRole('button', { name: 'Undo', exact: true }).click();
+	await expect
+		.poll(async () => (await scene(page)).elements.filter((e) => !e.isDeleted).map((e) => e.id))
+		.toEqual([original.id]);
+	expect(modelRequests).toEqual([]);
+});
+
+test('missing public artwork reports a retryable error without inserting a partial template', async ({
+	page
+}) => {
+	await page.route('**/assets/latent-space-hex-gradient.png', (route) =>
+		route.fulfill({ status: 503, body: 'Unavailable' })
+	);
+	await page.goto('/tools/draw');
+	await openDesignLibrary(page);
+	await page.getByRole('button', { name: 'Insert Latent Space thumbnail design' }).click();
+	await expect(
+		page.getByText('The template image could not be loaded. Try inserting again.', { exact: true })
+	).toBeVisible();
+	expect((await scene(page)).elements.filter((e) => !e.isDeleted)).toEqual([]);
+	expect(Object.keys((await scene(page)).files)).toEqual([]);
+	await page.unroute('**/assets/latent-space-hex-gradient.png');
+	await page.getByRole('button', { name: 'Insert Latent Space thumbnail design' }).click();
+	await expect(page.getByRole('region', { name: 'Selected design artboard' })).toBeVisible();
 });

--- a/tests/draw-designs.test.mjs
+++ b/tests/draw-designs.test.mjs
@@ -5,6 +5,7 @@ import {
 	createDrawingDesign,
 	DRAW_AGENT_WORKFLOWS,
 	DRAW_DESIGN_FORMATS,
+	DRAW_DESIGN_DEMO_PHOTO,
 	DRAW_DESIGN_TEMPLATES,
 	getDrawingDesignFormat
 } from '../src/lib/draw-designs.js';
@@ -12,7 +13,14 @@ import {
 test('design templates cover observed Canva thumbnail, speaker, banner, and slide workflows', () => {
 	assert.deepEqual(
 		DRAW_DESIGN_TEMPLATES.map((design) => design.id),
-		['ls-podcast', 'fde-decision', 'aie-speaker', 'blog-launch', 'keynote-slide']
+		[
+			'ls-podcast',
+			'fde-decision',
+			'thumbnail-evidence',
+			'aie-speaker',
+			'blog-launch',
+			'keynote-slide'
+		]
 	);
 	assert.deepEqual(
 		DRAW_DESIGN_FORMATS.map(({ id, width, height }) => [id, width, height]),
@@ -50,13 +58,13 @@ test('each design creates one exact-size native frame with independently editabl
 });
 
 test('Latent Space thumbnails use the official supplied logo and preserve YouTube timestamp clearance', () => {
-	for (const id of ['ls-podcast', 'fde-decision']) {
+	for (const id of ['ls-podcast', 'fde-decision', 'thumbnail-evidence']) {
 		const result = createDrawingDesign(id, {
 			logoFileId: 'official-logo',
 			headline: 'REAL EDITABLE HOOK',
 			companies: 'ACME   ·   EXAMPLE'
 		});
-		const logo = result.elements.find((element) => element.type === 'image');
+		const logo = result.elements.find((element) => element.fileId === 'official-logo');
 		assert.equal(logo?.fileId, 'official-logo');
 		assert.equal(logo?.width, logo?.height);
 		assert.ok(
@@ -73,23 +81,20 @@ test('Latent Space thumbnails use the official supplied logo and preserve YouTub
 	}
 });
 
-test('thumbnail hooks wrap and scale before overlapping the editable guest portrait', () => {
-	for (const id of ['ls-podcast', 'fde-decision']) {
+test('custom thumbnail hooks fit their headline regions without changing the guest photo', () => {
+	for (const id of ['ls-podcast', 'fde-decision', 'thumbnail-evidence']) {
 		const result = createDrawingDesign(id, { headline: 'HARNESS ENGINEERING' });
-		const headline = result.elements.find((element) =>
-			element.text?.includes('HARNESS')
-		);
-		assert.equal(headline?.text, 'HARNESS\nENGINEERING');
-		assert.ok(headline.fontSize <= (id === 'fde-decision' ? 76 : 86));
-		assert.ok(headline.x + 11 * headline.fontSize * 0.58 < 790);
+		const headline = result.elements.find((e) => e.customData?.designRole === 'headline');
+		assert.equal(headline.text.replaceAll('\n', ' '), 'HARNESS ENGINEERING');
+		assert.ok(headline.fontSize > 25);
+		const portrait = result.elements.find((e) => e.customData?.designRole === 'guest-photo');
+		assert.equal(portrait.fileId, DRAW_DESIGN_DEMO_PHOTO.id);
 	}
-
 	const lengthy = createDrawingDesign('ls-podcast', {
 		headline: 'BUILDING RELIABLE PRODUCTION AGENT ENGINEERING WORKFLOWS'
 	});
-	const headline = lengthy.elements.find((element) => element.text?.includes('BUILDING'));
-	assert.ok(headline.fontSize < 86);
-	assert.ok(headline.text.split('\n').length * headline.fontSize * 1.25 <= 225);
+	const headline = lengthy.elements.find((e) => e.customData?.designRole === 'headline');
+	assert.ok(headline.text.split('\n').length * headline.fontSize * 1.05 <= 435);
 });
 
 test('designs reject unknown templates without inventing people, identities, or companies', () => {
@@ -97,4 +102,36 @@ test('designs reject unknown templates without inventing people, identities, or 
 	const speaker = createDrawingDesign('aie-speaker');
 	assert.ok(speaker.elements.some((element) => element.text === 'SPEAKER\nNAME'));
 	assert.ok(speaker.elements.some((element) => element.text === 'The talk title goes here'));
+});
+
+test('photo-led starters preserve actual photo bytes and editable crop geometry, with no invented guests or companies', () => {
+	for (const id of ['ls-podcast', 'fde-decision', 'thumbnail-evidence']) {
+		const result = createDrawingDesign(id, {
+			photo: { fileId: 'my-real-guest', width: 800, height: 1200 }
+		});
+		const photos = result.elements.filter((e) => e.customData?.designRole === 'guest-photo');
+		assert.equal(photos.length, 1);
+		assert.equal(photos[0].fileId, 'my-real-guest');
+		assert.equal(photos[0].crop.naturalWidth, 800);
+		assert.equal(photos[0].crop.naturalHeight, 1200);
+		assert.ok(
+			Math.abs(photos[0].width / photos[0].height - photos[0].crop.width / photos[0].crop.height) <
+				0.00001
+		);
+		assert.ok(photos[0].crop.x >= 0 && photos[0].crop.y >= 0);
+		assert.equal(
+			result.elements.some((e) =>
+				/COMPANY ONE|YOUR SHARPEST|DROP GUEST|CONTEXT STACK/.test(e.text ?? '')
+			),
+			false
+		);
+		assert.equal(
+			result.elements.some((e) => e.strokeStyle === 'dashed'),
+			false
+		);
+	}
+	assert.throws(
+		() => createDrawingDesign('ls-podcast', { photo: { fileId: 'bad', width: 0, height: 300 } }),
+		/valid dimensions/
+	);
 });


### PR DESCRIPTION
## What changed

- Replace the generic thumbnail defaults with three distinct editable compositions: big claim + guest, comparison + guest, and evidence + reaction.
- Render gallery previews from the native design definitions, using the existing public swyx demo photo and official LS mark. Explicitly opt into copying a selected canvas photo; the original remains untouched. No copied creator photos, new assets, or private uploads.
- Keep non-YouTube formats under a collapsed Other formats section, with the AI Engineer concept disclaimer intact.
- Wait for bundled fonts/assets, recheck account/page/editor after async work, and append to the latest scene with one native undo capture.
- Correct Excalidraw's falsey-zero frame-coordinate behavior for initial insertion and duplication, fixing the 10px white export edge without changing export/resize helpers.

## Scope and integration

Approved source e1b5a4a integrated as fb1d51f atop current master b276f55; rejected af9b23c is excluded. Six files only: design definitions, preview component, narrow Design-tab/insertion hooks, and design/catalog tests. Existing thumbnail generation, providers, history, native Components, auth, daily receipts, and companion schema are unchanged.

## Verification

- 530 Node tests passed.
- 155 compiled-production browser tests passed; 4 explicit opt-in live-inference tests skipped.
- Svelte check: 0 errors, 0 warnings. Production build and diff checks passed.
- Native exports and desktop/390px gallery visually inspected. Tests cover all six designs, original-safe photo reuse, single Undo, delayed fonts/concurrent edits/page switch, retryable asset errors without partial insertion, frame/background and duplicate alignment, PNG corner pixels, reload, and PNG/JPG/SVG resize/export.
- Local verification used isolated DO/R2 and disabled/mocked inference. No paid inference, new dependencies, secrets, or config changes.

Main-only automatic release; companion Worker remains unchanged. Exact main activation and live read-only gallery verification will be posted after merge.
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/swyxio/swyxdotio/pull/586?analyze=true)

<a href="https://staging.itsdev.in/review/swyxio/swyxdotio/pull/586" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-staging-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-staging-light.svg?v=3" alt="Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/swyxio/swyxdotio/pull/586" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->