### PR TITLE
Bound OG rendering and fix presence monitoring semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,10 +243,17 @@ The site owns its social images rather than depending on Tailgraph or another ho
 - `/og/article/[slug].png?v=<updated-at>-<design-version>` resolves only public articles from the
   persisted content manifest. Unknown, private, and malformed slugs return 404.
 - Article `image`/`cover_image` values may enhance the template. Only HTTPS JPEG, PNG, and WebP
-  inputs up to 4 MB are accepted, with a 2.5-second fetch timeout. A bad image falls back to the
+  inputs up to 4 MB, two megapixels, and 2048 pixels per edge are accepted. A 2.5-second deadline
+  covers both headers and the streamed body. A bad or oversized image falls back to the
   no-image card rather than failing the request.
 - Generated PNGs are 1200×630, capped below 5 MB, and cached for one year as immutable. A complete
-  rendering failure returns `src/lib/og/assets/notebook-fallback.png` with `X-OG-Fallback: 1`.
+  rendering failure returns `src/lib/og/assets/notebook-fallback.png` with `X-OG-Fallback: 1`
+  and a 60-second cache TTL so a transient failure does not poison the card for a year.
+- HEAD validates the public card without fetching its cover or rasterizing a PNG. OG cache keys
+  ignore query strings because card inputs come only from the manifest/registry; Worker version
+  and content generation still invalidate the cache. Arbitrary `v` values cannot bypass it.
+- Cache-miss renders emit bounded `og_render` start/completion/fallback records with card kind,
+  image-present flag, elapsed time, and byte count. They never log card content or URLs.
 
 Every public page should use `src/components/SocialMeta.svelte`; do not add route-local duplicate
 Open Graph tags. Non-article pages use `og:type=website`, articles use `article`, and all metadata
@@ -262,8 +269,9 @@ curl -fsS "https://swyx.io/og/page/home.png?v=spotcheck" -o /tmp/swyx-og.png
 file /tmp/swyx-og.png
 ```
 
-Use a fresh version query when spot-checking so an older immutable edge entry cannot hide the new
-renderer. After deployment, also test a fresh X draft and LinkedIn Post Inspector; previously
+Deployment version and content generation invalidate internal OG cache entries. A fresh version
+query refreshes downstream social caches, but does not bypass the Worker's internal cache.
+After deployment, also test a fresh X draft and LinkedIn Post Inspector; previously
 shared URLs may retain network-owned caches.
 
 The focused unit suite validates registry coverage, metadata versioning, input rejection, image

--- a/docs/read-counter.md
+++ b/docs/read-counter.md
@@ -210,22 +210,33 @@ Each snapshot stores:
 - optional Cloudflare main-Worker request/error/status data for the last
   `MONITOR_LOOKBACK_MINUTES` window when `CLOUDFLARE_ANALYTICS_TOKEN` is set;
 - aggregate presence anomaly totals from `presence_monitor_hourly` for
-  `roomFull`, malformed-frame closes, and rate-limit events. Because those
+  `roomFull`, malformed-frame closes, and rate-limited **messages**. Because those
   counters are hourly and flushed at logarithmic checkpoints, the monitor reads
   completed, non-overlapping buckets. Current-hour events appear in the next
   scheduled snapshot instead of being
   skipped at a rolling-window boundary. Counts are exact at each checkpoint and
   conservative lower bounds between checkpoints.
+- Exact `attempts`, `connections`, and `rateLimitedConnections` events in the same
+  hourly table. Attempts are valid upgrades reaching the Durable Object; connections
+  are admitted sockets; rateLimitedConnections counts the first rate-limited message
+  per socket, with a hibernation-persistent marker. No identities enter D1. The first
+  violation can be in a later hour than admission, so hourly ratios are not matched
+  cohorts. No rows before rollout means unavailable coverage, not zero traffic.
+  These small exact counters add two writes per admitted connection and one per
+  first violation; they do not persist each movement/message. Persistence failures
+  emit only `presence.counter_failed` and the finite counter kind.
 
-The monitor alerts on three things by default:
+Calibration below `MONITOR_MIN_SAMPLE_COUNT` (`20`) is explicitly reported as
+statistically inactive in readiness notices. It is not an incident and does not
+increase `alert_count` or trigger the alert webhook.
 
-1. D1 samples since the latest calibration capture below
-   `MONITOR_MIN_SAMPLE_COUNT` (`20` by default), because calibration remains
-   statistically inactive below that per-window threshold.
-2. Elevated main-Worker `exceededResources` if both the count and rate exceed
+The monitor alerts on:
+
+1. Elevated main-Worker `exceededResources` if both the count and rate exceed
    the configured hourly thresholds.
-3. Any failed WebSocket open, welcome, or clean-close lifecycle check.
-4. Any persisted presence anomaly counts in the lookback window.
+2. Any failed public HTTP or WebSocket lifecycle smoke check.
+3. Any persisted presence anomaly counts in the lookback window.
+4. A completed calibration report with a delivery anomaly.
 
 The presence Worker explicitly enables `web_socket_auto_reply_to_close` so the
 runtime reciprocates normal close frames even though the Worker retains its

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
 				"@leeoniya/ufuzzy": "^1.0.8",
 				"date-fns": "^2.30.0",
 				"fflate": "0.8.3",
+				"image-size": "^2.0.2",
 				"jose": "^6.2.10",
 				"just-bash": "3.4.2",
 				"marked": "^12.0.0",
@@ -6040,6 +6041,18 @@
 			"license": "MIT",
 			"dependencies": {
 				"pica": "^7.1.0"
+			}
+		},
+		"node_modules/image-size": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/image-size/-/image-size-2.0.2.tgz",
+			"integrity": "sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w==",
+			"license": "MIT",
+			"bin": {
+				"image-size": "bin/image-size.js"
+			},
+			"engines": {
+				"node": ">=16.x"
 			}
 		},
 		"node_modules/immutable": {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
 		"@leeoniya/ufuzzy": "^1.0.8",
 		"date-fns": "^2.30.0",
 		"fflate": "0.8.3",
+		"image-size": "^2.0.2",
 		"jose": "^6.2.10",
 		"just-bash": "3.4.2",
 		"marked": "^12.0.0",

--- a/src/hooks.server.js
+++ b/src/hooks.server.js
@@ -72,6 +72,10 @@ export async function handle({ event, resolve }) {
 		isVersionedOgRequest(cacheUrl) ||
 		isPublicReadCountRequest(cacheUrl) ||
 		isPublicCrawlerDiscoveryRequest(cacheUrl);
+	// Card inputs come exclusively from the registry/manifest. Arbitrary query
+	// values (including v) must not force another expensive rasterization.
+	// Worker version + content generation below still invalidate changed cards.
+	if (cacheUrl.pathname.startsWith('/og/')) cacheUrl.search = '';
 	if (
 		cacheUrl.pathname === '/api/listContent.json' ||
 		cacheUrl.pathname === '/api/latestPosts.json' ||

--- a/src/lib/og/cards.js
+++ b/src/lib/og/cards.js
@@ -63,7 +63,7 @@ export function formatCardDate(value) {
  */
 export function getPageCard(key) {
 	const pageKey = /** @type {keyof typeof PAGE_SOCIAL_CARDS} */ (key);
-	const base = PAGE_SOCIAL_CARDS[pageKey];
+	const base = Object.hasOwn(PAGE_SOCIAL_CARDS, pageKey) ? PAGE_SOCIAL_CARDS[pageKey] : null;
 	if (!base) return null;
 	const title = truncateTitle(base.title);
 	return {
@@ -94,7 +94,7 @@ export function getArticleCard(article, image) {
 		kind: 'article',
 		title,
 		description: extractContentDescription('', article.description || article.subtitle || ''),
-		label: article.category || 'note',
+		label: `${article.category || 'note'}`.slice(0, 40),
 		date: formatCardDate(article.date),
 		image,
 		imageAlt,

--- a/src/lib/og/images.js
+++ b/src/lib/og/images.js
@@ -1,4 +1,8 @@
+import { imageSize } from 'image-size';
+
 const MAX_IMAGE_BYTES = 4 * 1024 * 1024;
+const MAX_IMAGE_PIXELS = 2_000_000;
+const MAX_IMAGE_EDGE = 2048;
 const IMAGE_TIMEOUT_MS = 2500;
 const SUPPORTED_TYPES = new Set(['image/jpeg', 'image/png', 'image/webp']);
 
@@ -32,33 +36,65 @@ export async function fetchCardImage(source, providedFetch, timeoutMs = IMAGE_TI
 	if (url.protocol !== 'https:') return undefined;
 
 	const controller = new AbortController();
+	/** @type {ReadableStreamDefaultReader<Uint8Array> | undefined} */
+	let reader;
 	/** @type {ReturnType<typeof setTimeout> | undefined} */
 	let timeout;
 	try {
-		const response = await Promise.race([
-			providedFetch(url, {
-				signal: controller.signal,
-				headers: { Accept: 'image/avif,image/webp,image/png,image/jpeg' }
-			}),
+		return await Promise.race([
+			(async () => {
+				const response = await providedFetch(url, {
+					signal: controller.signal,
+					headers: { Accept: 'image/webp,image/png,image/jpeg' }
+				});
+				if (!response.ok || !response.body) return undefined;
+				const contentType = (response.headers.get('content-type') || '')
+					.split(';')[0]
+					.toLowerCase();
+				if (!SUPPORTED_TYPES.has(contentType)) return undefined;
+				if (Number(response.headers.get('content-length') || 0) > MAX_IMAGE_BYTES) return undefined;
+				reader = response.body.getReader();
+				const chunks = [];
+				let size = 0;
+				while (!controller.signal.aborted) {
+					const { done, value } = await reader.read();
+					if (done) break;
+					size += value.byteLength;
+					if (size > MAX_IMAGE_BYTES) return undefined;
+					chunks.push(value);
+				}
+				if (controller.signal.aborted || !size) return undefined;
+				const bytes = new Uint8Array(size);
+				let offset = 0;
+				for (const chunk of chunks) {
+					bytes.set(chunk, offset);
+					offset += chunk.byteLength;
+				}
+				// Compressed byte size alone does not bound WASM decode work or memory.
+				const dimensions = imageSize(bytes);
+				if (
+					!['png', 'jpg', 'webp'].includes(dimensions.type ?? '') ||
+					!dimensions.width ||
+					!dimensions.height ||
+					dimensions.width > MAX_IMAGE_EDGE ||
+					dimensions.height > MAX_IMAGE_EDGE ||
+					dimensions.width * dimensions.height > MAX_IMAGE_PIXELS
+				)
+					return undefined;
+				return `data:${contentType};base64,${toBase64(bytes.buffer)}`;
+			})(),
 			new Promise((resolve) => {
 				timeout = setTimeout(() => {
 					controller.abort();
-					resolve(null);
+					resolve(undefined);
 				}, timeoutMs);
 			})
 		]);
-		if (!response) return undefined;
-		if (!response.ok) return undefined;
-		const contentType = (response.headers.get('content-type') || '').split(';')[0].toLowerCase();
-		if (!SUPPORTED_TYPES.has(contentType)) return undefined;
-		const declaredSize = Number(response.headers.get('content-length') || 0);
-		if (declaredSize > MAX_IMAGE_BYTES) return undefined;
-		const bytes = await response.arrayBuffer();
-		if (!bytes.byteLength || bytes.byteLength > MAX_IMAGE_BYTES) return undefined;
-		return `data:${contentType};base64,${toBase64(bytes)}`;
 	} catch {
 		return undefined;
 	} finally {
 		if (timeout) clearTimeout(timeout);
+		controller.abort();
+		void reader?.cancel().catch(() => {});
 	}
 }

--- a/src/lib/og/render.js
+++ b/src/lib/og/render.js
@@ -10,47 +10,66 @@ export const OG_CACHE_CONTROL =
 	'public, max-age=31536000, s-maxage=31536000, immutable, no-transform';
 const MAX_RENDERED_BYTES = 5 * 1024 * 1024;
 
-/** @param {unknown} error */
-function rendererErrorDetails(error) {
-	const details = [];
-	let current = error;
-	for (let depth = 0; depth < 5 && current && typeof current === 'object'; depth += 1) {
-		const record =
-			/** @type {{ name?: unknown, message?: unknown, code?: unknown, originalError?: unknown }} */ (
-				current
-			);
-		details.push({ name: record.name, message: record.message, code: record.code });
-		current = record.originalError;
-	}
-	return details;
+/** HEAD validates the card without paying for rasterization. */
+export function notebookCardHead() {
+	return new Response(null, {
+		headers: { 'Content-Type': 'image/png', 'Cache-Control': OG_CACHE_CONTROL }
+	});
 }
 
 /** @param {import('./cards').NotebookCard} card */
 export async function renderNotebookCard(card) {
+	const started = Date.now();
+	let stage = 'fonts';
 	try {
+		const fonts = await notebookFonts();
+		stage = 'render';
+		console.log(
+			JSON.stringify({
+				event: 'og_render',
+				stage: 'start',
+				kind: card.kind,
+				hasImage: !!card.image
+			})
+		);
 		const generated = new ImageResponse(renderNotebookTemplate(card, portrait), {
 			width: OG_WIDTH,
 			height: OG_HEIGHT,
 			format: 'png',
-			fonts: await notebookFonts(),
+			fonts,
 			headers: { 'Cache-Control': OG_CACHE_CONTROL }
 		});
 		const bytes = await generated.arrayBuffer();
 		if (bytes.byteLength > MAX_RENDERED_BYTES) throw new Error('Rendered OG image exceeds 5 MB');
+		console.log(
+			JSON.stringify({
+				event: 'og_render',
+				stage: 'complete',
+				kind: card.kind,
+				durationMs: Date.now() - started,
+				bytes: bytes.byteLength
+			})
+		);
 		return new Response(bytes, {
 			headers: {
 				'Content-Type': 'image/png',
 				'Cache-Control': OG_CACHE_CONTROL
 			}
 		});
-	} catch (error) {
-		console.error('OG image render failed; serving fallback', {
-			errors: rendererErrorDetails(error)
-		});
+	} catch {
+		console.error(
+			JSON.stringify({
+				event: 'og_render',
+				stage,
+				outcome: 'fallback',
+				kind: card.kind,
+				durationMs: Date.now() - started
+			})
+		);
 		return new Response(await read(fallbackPath).arrayBuffer(), {
 			headers: {
 				'Content-Type': 'image/png',
-				'Cache-Control': OG_CACHE_CONTROL,
+				'Cache-Control': 'public, max-age=60, s-maxage=60',
 				'X-OG-Fallback': '1'
 			}
 		});

--- a/src/routes/og/article/[slug].png/+server.js
+++ b/src/routes/og/article/[slug].png/+server.js
@@ -2,9 +2,16 @@ import { error } from '@sveltejs/kit';
 import { readContentManifest } from '$lib/content-manifest.js';
 import { resolveArticleCard } from '$lib/og/article.js';
 import { fetchCardImage } from '$lib/og/images.js';
-import { renderNotebookCard } from '$lib/og/render.js';
+import { notebookCardHead, renderNotebookCard } from '$lib/og/render.js';
 
 export const prerender = false;
+
+/** @type {import('./$types').RequestHandler} */
+export async function HEAD({ params, platform }) {
+	const manifest = await readContentManifest(platform?.env?.CONTENT_MANIFEST);
+	if (!resolveArticleCard(manifest, params.slug)) throw error(404, 'Unknown article');
+	return notebookCardHead();
+}
 
 /** @type {import('./$types').RequestHandler} */
 export async function GET({ params, platform }) {

--- a/src/routes/og/page/[key].png/+server.js
+++ b/src/routes/og/page/[key].png/+server.js
@@ -1,8 +1,14 @@
 import { error } from '@sveltejs/kit';
 import { getPageCard } from '$lib/og/cards.js';
-import { renderNotebookCard } from '$lib/og/render.js';
+import { notebookCardHead, renderNotebookCard } from '$lib/og/render.js';
 
 export const prerender = false;
+
+/** @type {import('./$types').RequestHandler} */
+export function HEAD({ params }) {
+	if (!getPageCard(params.key)) throw error(404, 'Unknown OG page');
+	return notebookCardHead();
+}
 
 /** @type {import('./$types').RequestHandler} */
 export async function GET({ params }) {

--- a/tests/og-cards.test.mjs
+++ b/tests/og-cards.test.mjs
@@ -14,6 +14,7 @@ test('page registry covers every public non-article card variant', () => {
 		['identity', 'identity', 'collection', 'audio', 'portfolio', 'newsletter']
 	);
 	assert.equal(getPageCard('tools'), null);
+	assert.equal(getPageCard('toString'), null);
 	assert.equal(getPageCard('now')?.kind, 'identity');
 	assert.equal(getPageCard('now')?.annotation, 'a note from the present');
 });
@@ -69,14 +70,18 @@ test('invalid dates are omitted', () => {
 });
 
 test('frontmatter images require bounded successful HTTPS image responses', async () => {
+	const png = Buffer.from(
+		'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+jR1kAAAAASUVORK5CYII=',
+		'base64'
+	);
 	const image = await fetchCardImage(
 		'https://images.example/card.png',
 		async () =>
-			new Response(new Uint8Array([137, 80, 78, 71]), {
-				headers: { 'content-type': 'image/png', 'content-length': '4' }
+			new Response(png, {
+				headers: { 'content-type': 'image/png' }
 			})
 	);
-	assert.equal(image, 'data:image/png;base64,iVBORw==');
+	assert.equal(image, `data:image/png;base64,${png.toString('base64')}`);
 	assert.equal(await fetchCardImage('http://images.example/card.png', fetch), undefined);
 	assert.equal(
 		await fetchCardImage(

--- a/tests/og-resource-bounds.test.mjs
+++ b/tests/og-resource-bounds.test.mjs
@@ -1,0 +1,114 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { fetchCardImage } from '../src/lib/og/images.js';
+import { handle } from '../src/hooks.server.js';
+
+test('image deadline includes a stalled body, even when it ignores abort', async () => {
+	let cancelled = false;
+	const start = performance.now();
+	const image = await fetchCardImage(
+		'https://example.test/image.png',
+		async () =>
+			new Response(
+				new ReadableStream({
+					cancel() {
+						cancelled = true;
+					}
+				}),
+				{
+					headers: { 'content-type': 'image/png' }
+				}
+			),
+		20
+	);
+	assert.equal(image, undefined);
+	assert.ok(performance.now() - start < 500);
+	assert.equal(cancelled, true);
+});
+
+test('stream size is bounded without trusting Content-Length', async () => {
+	let pulls = 0;
+	let cancelled = false;
+	const image = await fetchCardImage(
+		'https://example.test/image.png',
+		async () =>
+			new Response(
+				new ReadableStream({
+					pull(controller) {
+						pulls++;
+						controller.enqueue(new Uint8Array(1024 * 1024));
+					},
+					cancel() {
+						cancelled = true;
+					}
+				}),
+				{ headers: { 'content-type': 'image/png', 'content-length': '100' } }
+			)
+	);
+	assert.equal(image, undefined);
+	assert.ok(pulls <= 6);
+	assert.equal(cancelled, true);
+});
+
+test('tiny compressed images with excessive decoded dimensions are rejected', async () => {
+	const bytes = Buffer.from(
+		'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+jR1kAAAAASUVORK5CYII=',
+		'base64'
+	);
+	bytes.writeUInt32BE(10000, 16);
+	bytes.writeUInt32BE(10000, 20);
+	assert.equal(
+		await fetchCardImage(
+			'https://example.test/image.png',
+			async () => new Response(bytes, { headers: { 'content-type': 'image/png' } })
+		),
+		undefined
+	);
+});
+
+test('OG query noise shares cache while content generation still invalidates', async () => {
+	const original = globalThis.caches;
+	const entries = new Map();
+	let generation = 'one';
+	let renders = 0;
+	globalThis.caches = {
+		default: {
+			async match(req) {
+				return entries.get(req.url)?.clone();
+			},
+			async put(req, response) {
+				entries.set(req.url, response);
+			}
+		}
+	};
+	const request = async (query) =>
+		handle({
+			event: {
+				request: new Request(`https://swyx.io/og/page/home.png?${query}`),
+				platform: {
+					env: {
+						CF_VERSION_METADATA: { id: 'version-one' },
+						CONTENT_MANIFEST: {
+							async get() {
+								return generation;
+							}
+						}
+					}
+				}
+			},
+			resolve: async () => {
+				renders++;
+				return new Response('PNG', { headers: { 'Cache-Control': 'public, s-maxage=3600' } });
+			}
+		});
+	try {
+		await request('v=one');
+		await request('v=two&random=three');
+		assert.equal(renders, 1);
+		generation = 'two';
+		await request('v=two');
+		assert.equal(renders, 2);
+	} finally {
+		globalThis.caches = original;
+	}
+});

--- a/tests/presence-server.test.mjs
+++ b/tests/presence-server.test.mjs
@@ -77,3 +77,60 @@ test('presence room reciprocates valid close frames without echoing the peer rea
 
 	assert.deepEqual(replies, [[1000, '']]);
 });
+
+test('connection telemetry is exact and affected sockets are counted once across hibernation', async () => {
+	const increments = [];
+	const pending = [];
+	const database = {
+		prepare() {
+			return {
+				bind(...args) {
+					increments.push(args);
+					return { async run() {} };
+				}
+			};
+		}
+	};
+	const ctx = {
+		getWebSockets: () => [],
+		waitUntil(promise) {
+			pending.push(promise);
+		}
+	};
+	const room = new PresenceRoom(ctx, { READ_COUNTERS: database });
+	const oldWarn = console.warn;
+	console.warn = () => {};
+	try {
+		for (let i = 0; i < 3; i++) {
+			room.report('attempts');
+			room.report('connections');
+		}
+		let attachment = { id: 'test-only' };
+		const socket = {
+			deserializeAttachment: () => attachment,
+			serializeAttachment(value) {
+				attachment = value;
+			},
+			close() {}
+		};
+		for (const instance of [room, new PresenceRoom(ctx, { READ_COUNTERS: database })]) {
+			instance.rateStates.set('test-only', {
+				tokens: 0,
+				replenishedAt: Date.now() + 60000,
+				violations: 0
+			});
+			instance.webSocketMessage(socket, '');
+			instance.webSocketMessage(socket, '');
+		}
+		await Promise.all(pending);
+		const total = (kind) =>
+			increments.filter((row) => row[1] === kind).reduce((n, row) => n + row[2], 0);
+		assert.equal(total('connections'), 3);
+		assert.equal(total('attempts'), 3);
+		assert.equal(total('rateLimitedConnections'), 1);
+		assert.ok(increments.every((row) => row.length === 3 && typeof row[0] === 'number'));
+		assert.doesNotMatch(JSON.stringify(increments), /test-only/);
+	} finally {
+		console.warn = oldWarn;
+	}
+});

--- a/tests/read-presence-monitor.test.mjs
+++ b/tests/read-presence-monitor.test.mjs
@@ -98,7 +98,10 @@ test('presence count query binds the completed bucket window', async () => {
 	assert.deepEqual(await readPresenceCounts(database, capturedAt, 60), {
 		roomFull: 0,
 		malformed: 0,
-		rateLimited: 4
+		rateLimited: 4,
+		attempts: null,
+		connections: null,
+		rateLimitedConnections: null
 	});
 	assert.match(sql, /bucket_start >= \?1 AND bucket_start < \?2/);
 	assert.deepEqual(bindings, [
@@ -242,7 +245,8 @@ test('monitor flags insufficient samples and elevated exceededResources', () => 
 		config
 	});
 	assert.equal(analysis.status, 'alert');
-	assert.match(analysis.alerts.join('\n'), /Calibration remains statistically inactive/);
+	assert.match(analysis.notices.join('\n'), /Calibration remains statistically inactive/);
+	assert.equal(analysis.alerts.length, 1);
 	assert.match(analysis.alerts.join('\n'), /exceededResources is elevated/);
 });
 
@@ -310,4 +314,6 @@ test('rendered monitor report includes public read checks and alerts', () => {
 	assert.match(report, /Current calibration window: 7\/20 samples/);
 	assert.match(report, /Presence WebSocket smoke: open ok, welcome ok, close clean/);
 	assert.match(report, /Calibration remains statistically inactive/);
+	assert.equal(analysis.status, 'ok');
+	assert.deepEqual(analysis.alerts, []);
 });

--- a/workers/presence/index.js
+++ b/workers/presence/index.js
@@ -15,7 +15,15 @@ const POLICY_VIOLATION = 1008;
 const TRY_AGAIN_LATER = 1013;
 const REACTION_INTERVAL_MS = 2_000;
 const RATE_LIMIT_CLOSE_THRESHOLD = 20;
-const PERSISTED_PRESENCE_KINDS = new Set(['roomFull', 'malformed', 'rateLimited']);
+const PERSISTED_PRESENCE_KINDS = new Set([
+	'roomFull',
+	'malformed',
+	'rateLimited',
+	'connections',
+	'attempts',
+	'rateLimitedConnections'
+]);
+const EXACT_PRESENCE_KINDS = new Set(['connections', 'attempts', 'rateLimitedConnections']);
 const UNSENDABLE_CLOSE_CODES = new Set([1004, 1005, 1006]);
 
 function socketAttachment(socket) {
@@ -80,13 +88,15 @@ export class PresenceRoom {
 		}
 		const count = (this.aggregateCounts[kind] ?? 0) + 1;
 		this.aggregateCounts[kind] = count;
-		const persistedDelta = presenceAggregateDelta(count);
+		const persistedDelta = EXACT_PRESENCE_KINDS.has(kind) ? 1 : presenceAggregateDelta(count);
 		// Emit sparse aggregate-only diagnostics. Never include room, peer, country,
 		// position, reaction, URL, user agent, or network identifiers.
-		if (persistedDelta > 0) console.warn('presence.aggregate', { kind, count });
+		if (presenceAggregateDelta(count) > 0) console.warn('presence.aggregate', { kind, count });
 		if (persistedDelta > 0 && PERSISTED_PRESENCE_KINDS.has(kind) && this.env?.READ_COUNTERS) {
 			this.ctx.waitUntil(
-				incrementPresenceCounter(this.env.READ_COUNTERS, kind, persistedDelta, bucketStart)
+				incrementPresenceCounter(this.env.READ_COUNTERS, kind, persistedDelta, bucketStart).catch(
+					() => console.error('presence.counter_failed', { kind })
+				)
 			);
 		}
 	}
@@ -113,6 +123,7 @@ export class PresenceRoom {
 			return new Response('WebSocket upgrade required', { status: 426 });
 		}
 
+		this.report('attempts');
 		if (this.peers.length >= PRESENCE_ROOM_LIMIT) {
 			this.report('roomFull');
 			const pair = new WebSocketPair();
@@ -164,6 +175,12 @@ export class PresenceRoom {
 		this.rateStates.set(peer.id, state);
 		if (!consumePresenceToken(state)) {
 			this.report('rateLimited');
+			// Attachment survives hibernation; count each affected connection once.
+			if (!peer.rateLimitedReported) {
+				peer.rateLimitedReported = true;
+				socket.serializeAttachment(peer);
+				this.report('rateLimitedConnections');
+			}
 			if (state.violations >= RATE_LIMIT_CLOSE_THRESHOLD) {
 				close(socket, POLICY_VIOLATION, 'Rate limit exceeded');
 			}

--- a/workers/read-presence-monitor/index.js
+++ b/workers/read-presence-monitor/index.js
@@ -159,12 +159,22 @@ export async function readPresenceCounts(database, capturedAt, lookbackMinutes) 
 		)
 		.bind(window.start, window.end)
 		.all();
-	const counts = { roomFull: 0, malformed: 0, rateLimited: 0 };
+	const counts = {
+		roomFull: 0,
+		malformed: 0,
+		rateLimited: 0,
+		attempts: /** @type {number | null} */ (null),
+		connections: /** @type {number | null} */ (null),
+		rateLimitedConnections: /** @type {number | null} */ (null)
+	};
 	for (const row of rows.results ?? []) {
 		const key = `${row.kind}`;
 		if (key === 'roomFull') counts.roomFull = Number(row.count ?? 0);
 		if (key === 'malformed') counts.malformed = Number(row.count ?? 0);
 		if (key === 'rateLimited') counts.rateLimited = Number(row.count ?? 0);
+		if (key === 'attempts') counts.attempts = Number(row.count ?? 0);
+		if (key === 'connections') counts.connections = Number(row.count ?? 0);
+		if (key === 'rateLimitedConnections') counts.rateLimitedConnections = Number(row.count ?? 0);
 	}
 	return counts;
 }

--- a/workers/read-presence-monitor/monitor.js
+++ b/workers/read-presence-monitor/monitor.js
@@ -62,9 +62,10 @@ export function monitorConfig(env) {
  */
 export function analyzeMonitor(input) {
 	const alerts = [];
+	const notices = [];
 
 	if (input.calibrationSampleCount < input.config.minSampleCount) {
-		alerts.push(
+		notices.push(
 			`Calibration remains statistically inactive: ${input.calibrationSampleCount}/${input.config.minSampleCount} D1 samples in the current window`
 		);
 	}
@@ -104,7 +105,9 @@ export function analyzeMonitor(input) {
 		alerts.push(`Presence malformed-frame closes detected: ${input.presenceCounts.malformed}`);
 	}
 	if (input.presenceCounts.rateLimited > 0) {
-		alerts.push(`Presence rate-limit events detected: ${input.presenceCounts.rateLimited}`);
+		alerts.push(
+			`Presence rate-limited messages detected (lower bound): ${input.presenceCounts.rateLimited}`
+		);
 	}
 
 	if (input.calibrationStatus === 'delivery_anomaly') {
@@ -113,7 +116,8 @@ export function analyzeMonitor(input) {
 
 	return {
 		status: alerts.length ? 'alert' : 'ok',
-		alerts
+		alerts,
+		notices
 	};
 }
 
@@ -127,7 +131,7 @@ export function analyzeMonitor(input) {
  *  smoke: { readBatchOk: boolean; presenceHttpOk: boolean; publicReads: Record<string, number>; };
  *  presenceSocket: { openOk: boolean; welcomeOk: boolean; closeOk: boolean; failureStage: string | null; closeCode: number | null; durationMs: number; };
  *  worker: { requests: number | null; errors: number | null; exceededResources: number | null; clientDisconnected: number | null; };
- *  presence: { roomFull: number; malformed: number; rateLimited: number; };
+ *  presence: { roomFull: number; malformed: number; rateLimited: number; attempts?: number | null; connections?: number | null; rateLimitedConnections?: number | null; };
  *  analysis: ReturnType<typeof analyzeMonitor>;
  * }} snapshot
  */
@@ -152,12 +156,14 @@ export function renderMonitorReport(snapshot) {
 - Lookback: ${snapshot.config.lookbackMinutes} minutes
 - D1 totals: ${snapshot.totals.readCount.toLocaleString('en-US')} reads, ${snapshot.totals.sampleCount.toLocaleString('en-US')} samples
 - Current calibration window: ${snapshot.calibrationSampleCount.toLocaleString('en-US')}/${snapshot.config.minSampleCount.toLocaleString('en-US')} samples
+- Calibration readiness: ${snapshot.analysis.notices.join(' | ') || 'minimum sample threshold met; precision and freshness still require review'}
 - Latest calibration row: ${snapshot.calibration.status ?? 'none'}${snapshot.calibration.captured_at ? ` at ${new Date(snapshot.calibration.captured_at * 1000).toISOString()}` : ''}
 - Public read smoke: ${snapshot.smoke.readBatchOk ? 'ok' : 'failed'}
 - Presence HTTP smoke: ${snapshot.smoke.presenceHttpOk ? 'ok' : 'failed'}
 - Presence WebSocket smoke: ${presenceSocket}
 - Main Worker window: ${workerWindow}
-- Presence anomalies: room-full ${snapshot.presence.roomFull}, malformed ${snapshot.presence.malformed}, rate-limited ${snapshot.presence.rateLimited}
+- Presence anomalies (checkpoint lower bounds): room-full ${snapshot.presence.roomFull}, malformed ${snapshot.presence.malformed}, rate-limited messages ${snapshot.presence.rateLimited}
+- Presence connection counts: attempts ${snapshot.presence.attempts ?? 'unavailable'}, admitted ${snapshot.presence.connections ?? 'unavailable'}, first rate limit on connection ${snapshot.presence.rateLimitedConnections ?? (snapshot.presence.connections !== null && snapshot.presence.connections !== undefined ? 0 : 'unavailable')}. These count events in this hour, not a matched connection cohort.
 - Public reads checked: ${Object.entries(snapshot.smoke.publicReads)
 		.map(([key, value]) => `${key}=${value}`)
 		.join(', ')}


### PR DESCRIPTION
OG requests could force repeated rasterization through arbitrary query strings or HEAD requests, and cover-image limits did not bound decoded pixels or stalled response bodies. Reuse version/content-invalidated cache entries across query variants, validate HEAD without rendering, bound downloads to 4 MB/2.5 seconds and decoding to two megapixels/2048px, and give transient fallback images a 60-second TTL. Add content-free render diagnostics.

Report fewer than 20 post-calibration samples as a readiness notice instead of an incident. Persist exact aggregate connection attempts, admissions, and first-rate-limited sockets; retain existing lower-bound message anomaly counters and label their meaning correctly. Socket deduplication survives hibernation. Admission remains 1.

Validation: 532 unit tests pass; zero Svelte/type errors; production build succeeds; presence and monitor Wrangler dry runs pass. Local Cloudflare runtime: six public cards produce 1200×630 PNGs without fallback; home cold render 532ms, query-variant cache hit 3ms, HEAD 9ms with no render event. Invalid registry keys return 404. Historical CPU-spike elimination still requires observation after deployment.

<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/swyxio/swyxdotio/pull/588?analyze=true)

<a href="https://staging.itsdev.in/review/swyxio/swyxdotio/pull/588" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-staging-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-staging-light.svg?v=3" alt="Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/swyxio/swyxdotio/pull/588" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->